### PR TITLE
Fix #9 by making sure dict construction uses the generic StringType c…

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,8 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [targets]
-test = ["Test"]
+test = ["Test", "UUIDs"]
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -510,7 +510,7 @@ construct(::Type{NamedTuple{names}}, x::Dict) where {names} = NamedTuple{names}(
 construct(::Type{NamedTuple{names, types}}, x::Dict) where {names, types} = NamedTuple{names, types}(Tuple(x[nm] for nm in names))
 
 keyvalue(::Type{Symbol}, escaped, ptr, len) = escaped ? Symbol(unescape(PointerString(ptr, len))) : _symbol(ptr, len)
-keyvalue(::Type{String}, escaped, ptr, len) = escaped ? unescape(PointerString(ptr, len)) : unsafe_string(ptr, len)
+keyvalue(::Type{T}, escaped, ptr, len) where {T} = escaped ? construct(T, unescape(PointerString(ptr, len))) : construct(T, unsafe_string(ptr, len))
 
 @inline read(::ObjectType, buf, pos, len, b, ::Type{T}) where {T} = read(ObjectType(), buf, pos, len, b, T, Symbol, Any)
 @inline read(::ObjectType, buf, pos, len, b, ::Type{T}) where {T <: NamedTuple} = read(ObjectType(), buf, pos, len, b, T, Symbol, Any)
@@ -570,7 +570,7 @@ keyvalue(::Type{String}, escaped, ptr, len) = escaped ? unescape(PointerString(p
         @wh
         # now positioned at start of value
         pos, y = read(StructType(V), buf, pos, len, b, V)
-        x[K(key)] = y
+        x[key] = y
         @eof
         b = getbyte(buf, pos)
         @wh

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using Test, JSON3
+using Test, JSON3, UUIDs
 
 @enum Fruit apple banana
 
@@ -562,5 +562,9 @@ txt = """
 @test eltype(JSON3.read("[1.2, 2.0]")) === Float64
 @test eltype(JSON3.read("[1.2, 2.0, 3.3]")) === Float64
 
+# https://github.com/quinnj/JSON3.jl/issues/9
+d = Dict(uuid1() => i for i in 1:3)
+t = JSON3.write(d)
+@test JSON3.read(t, Dict{UUID, Int}) == d
 
 end # @testset "JSON3"


### PR DESCRIPTION
…onstruction machinery. This means that basically any type can be the key type of a Dict as long as it (implicitly) satisfies the StringType interface