### PR TITLE
Retain eltypes for numeric array containing only Int/Float/null

### DIFF
--- a/src/JSON3.jl
+++ b/src/JSON3.jl
@@ -98,7 +98,7 @@ function Base.iterate(arr::Array{T}, (i, tapeidx)=(1, 3)) where {T}
     i > length(arr) && return nothing
     tape = gettape(arr)
     @inbounds t = tape[tapeidx]
-    val = getvalue(T, getbuf(arr), tape, tapeidx, t)
+    val = getvalue(Any, getbuf(arr), tape, tapeidx, t)
     tapeidx += gettapelen(T, t)
     return val, (i + 1, tapeidx)
 end
@@ -110,7 +110,7 @@ end
     if regularstride(T)
         tapeidx = 1 + 2 * i
         @inbounds t = tape[tapeidx]
-        return getvalue(T, buf, tape, tapeidx, t)
+        return getvalue(Any, buf, tape, tapeidx, t)
     else
         tapeidx = 3
         idx = 1

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -78,10 +78,10 @@ function promoteeltype(A, B)
         return B
     elseif (A | B) == A
         return A
-    elseif A == INT && B == FLOAT
-        return A | B
-    elseif A == FLOAT && B == INT
-        return A | B
+    elseif A & INT == INT && B == FLOAT
+        return A & ~INT | FLOAT
+    elseif A & FLOAT == FLOAT && B == INT
+        return A
     elseif A == NULL || B == NULL
         return A | B
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -561,6 +561,10 @@ txt = """
 # https://github.com/quinnj/JSON3.jl/issues/8
 @test eltype(JSON3.read("[1.2, 2.0]")) === Float64
 @test eltype(JSON3.read("[1.2, 2.0, 3.3]")) === Float64
+@test eltype(JSON3.read("[1, 2]")) == Int64
+@test eltype(JSON3.read("[1, 2.3]")) == Float64
+@test eltype(JSON3.read("[1, null, 2]")) == Union{Nothing,Int64}
+@test eltype(JSON3.read("[1, null, 2.3]")) == Union{Nothing,Float64}
 
 # https://github.com/quinnj/JSON3.jl/issues/9
 d = Dict(uuid1() => i for i in 1:3)


### PR DESCRIPTION
To address [the loss of eltype](https://github.com/quinnj/JSON3.jl/issues/8#issuecomment-507224261) information in numeric arrays, I tried to implement the following logic:
- if at least a float is encountered, then eltype is `Float64`, otherwise it's `Int64`
- if a `null` is encounterd, then eltype is the union of the previous item and `Nothing`.

The only possible eltypes for numerical arrays should be `Int64`, `Float64`, `Union{Int64,Nothing}` and `Union{Float64,Nothing}`.

`Any` should appear only if something that is not a `Int`, `Float` or `null` is encountered.