### PR TITLE
grab bag of perf improvements

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -666,16 +666,21 @@ end
             32,
             i -> (i <= N && fieldname(T, i) === key),
             i -> begin
-                FT = fieldtype(T, i)
-                pos, y_i = read(StructType(FT), buf, pos, len, b, FT)
-                is_included && setfield!(x, key, y_i)
+                FT_i = fieldtype(T, i)
+                pos, y_i = read(StructType(FT_i), buf, pos, len, b, FT_i)
+                is_included && setfield!(x, i, y_i)
             end,
             i -> begin
-                j = Base.fieldindex(T, key, false)
-                if j > 0
-                    pos, y_j = read(StructType(FT), buf, pos, len, b, FT)
-                    is_included && setfield!(x, key, y_j)
-                else
+                is_field_still_unread = true
+                for j in 33:N
+                    fieldname(T, j) === key || continue
+                    FT_j = fieldtype(T, j)
+                    pos, y_j = read(StructType(FT_j), buf, pos, len, b, FT_j)
+                    is_included && setfield!(x, j, y_j)
+                    is_field_still_unread = false
+                    break
+                end
+                if is_field_still_unread
                     pos, _ = read(Struct(), buf, pos, len, b, Any)
                 end
             end

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -605,8 +605,6 @@ keyvalue(::Type{T}, escaped, ptr, len) where {T} = escaped ? construct(T, unesca
     invalid(error, buf, pos, Object)
 end
 
-@noinline _throw_100_field_error() = error("JSON3 does not yet support struct-based deserialization for structs with more than 100 fields")
-
 @inline function read(::Mutable, buf, pos, len, b, ::Type{T}) where {T}
     if b != UInt8('{')
         error = ExpectedOpeningObjectChar
@@ -662,6 +660,7 @@ end
         b = getbyte(buf, pos)
         @wh
         is_included = !symbolin(excl, key)
+        # unroll the first 32 field checks to avoid dynamic dispatch if possible
         Base.@nif(
             32,
             i -> (i <= N && fieldname(T, i) === key),

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -663,19 +663,18 @@ end
         b = getbyte(buf, pos)
         @wh
         is_included = !symbolin(excl, key)
-        is_field_still_unread = true
-        Base.@nexprs 100 i -> begin
-            if i <= N && fieldname(T, i) === key
+        Base.@nif(
+            100,
+            i -> (i <= N && fieldname(T, i) === key),
+            i -> begin
                 FT = fieldtype(T, i)
                 pos, y = read(StructType(FT), buf, pos, len, b, FT)
                 is_included && setfield!(x, key, y)
-                is_field_still_unread = false
+            end,
+            i -> begin
+                pos, _ = read(Struct(), buf, pos, len, b, Any)
             end
-        end
-        if is_field_still_unread
-            # read the unknown key's value, but ignore it
-            pos, _ = read(Struct(), buf, pos, len, b, Any)
-        end
+        )
         @eof
         b = getbyte(buf, pos)
         @wh


### PR DESCRIPTION
I have a bunch of JSON that parses faster via JSON.jl's `JSON.parse` than `JSON3.read(data, MyType)` (where I've set things up such that `JSON3.StructType(MyType) == JSON3.Mutable()`.

This PR implements a few minor perf improvements; still about 2x slower than JSON.jl but I suspect we'll find the culprits before the end of JuliaCon.