### PR TITLE
Improve Mutable read perf by ensuring we merge NamedTuples and not fa…

### DIFF
--- a/benchmarks/benchmarks.jl
+++ b/benchmarks/benchmarks.jl
@@ -1,0 +1,28 @@
+using JSON3, StructTypes, BenchmarkTools
+
+mutable struct T
+    a::Int
+    b::Float64
+    c::String
+    null::Nothing
+    maybe::Union{Int, Nothing}
+    T() = new()
+end
+
+JSON3.StructType(::Type{T}) = JSON3.Mutable()
+StructTypes.StructType(::Type{T}) = StructTypes.Mutable()
+
+@btime JSON3.read("{}", T)
+
+@btime JSON3.read(b"""
+{
+    "a": 1,
+    "b": 3.14,
+    "c": "hey",
+    "null": null,
+    "maybe": 10
+}""", T)
+
+# master:   4.114 μs (62 allocations: 6.70 KiB)
+# 0.1.13:    3.784 μs (16 allocations: 400 bytes)
+# new:   950.759 ns (11 allocations: 432 bytes)

--- a/src/read.jl
+++ b/src/read.jl
@@ -2,16 +2,17 @@ struct VectorString{T <: AbstractVector{UInt8}} <: AbstractString
     bytes::T
 end
 
-Base.ncodeunits(s::VectorString) = length(s.bytes)
-Base.codeunit(s::VectorString) = UInt8
-Base.length(s::VectorString) = ncodeunits(s)
-function Base.codeunit(s::VectorString, i::Int)
-    @inbounds b = s.bytes[i]
-    return b
-end
-Base.pointer(v::VectorString) = pointer(v.bytes)
-Base.pointer(v::VectorString, i::Integer) = pointer(v.bytes, i)
-Base.unsafe_convert(::Type{Ptr{UInt8}}, v::VectorString) = pointer(v)
+Base.codeunits(x::VectorString) = x.bytes
+# Base.ncodeunits(s::VectorString) = length(s.bytes)
+# Base.codeunit(s::VectorString) = UInt8
+# Base.length(s::VectorString) = ncodeunits(s)
+# function Base.codeunit(s::VectorString, i::Int)
+#     @inbounds b = s.bytes[i]
+#     return b
+# end
+# Base.pointer(v::VectorString) = pointer(v.bytes)
+# Base.pointer(v::VectorString, i::Integer) = pointer(v.bytes, i)
+# Base.unsafe_convert(::Type{Ptr{UInt8}}, v::VectorString) = pointer(v)
 
 # high-level user API functions
 read(io::IO) = read(Base.read(io, String))

--- a/src/read.jl
+++ b/src/read.jl
@@ -1,18 +1,9 @@
+# temporary wrapper to pass byte vector through
 struct VectorString{T <: AbstractVector{UInt8}} <: AbstractString
     bytes::T
 end
 
 Base.codeunits(x::VectorString) = x.bytes
-# Base.ncodeunits(s::VectorString) = length(s.bytes)
-# Base.codeunit(s::VectorString) = UInt8
-# Base.length(s::VectorString) = ncodeunits(s)
-# function Base.codeunit(s::VectorString, i::Int)
-#     @inbounds b = s.bytes[i]
-#     return b
-# end
-# Base.pointer(v::VectorString) = pointer(v.bytes)
-# Base.pointer(v::VectorString, i::Integer) = pointer(v.bytes, i)
-# Base.unsafe_convert(::Type{Ptr{UInt8}}, v::VectorString) = pointer(v)
 
 # high-level user API functions
 read(io::IO) = read(Base.read(io, String))

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -67,7 +67,7 @@ end
     invalid(InvalidChar, buf, pos, Any)
 end
 
-@inline function read(::StringType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+function read(::StringType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     if b != UInt8('"')
         error = ExpectedOpeningQuoteChar
         @goto invalid
@@ -98,7 +98,7 @@ end
     invalid(error, buf, pos, T)
 end
 
-@inline function read(::BoolType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+function read(::BoolType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     if pos + 3 <= len &&
         b            == UInt8('t') &&
         buf[pos + 1] == UInt8('r') &&
@@ -117,7 +117,7 @@ end
     end
 end
 
-@inline function read(::NullType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+function read(::NullType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     if pos + 3 <= len &&
         b            == UInt8('n') &&
         buf[pos + 1] == UInt8('u') &&
@@ -129,7 +129,7 @@ end
     end
 end
 
-@inline function read(::NumberType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+function read(::NumberType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     x, code, pos = Parsers.typeparser(StructTypes.numbertype(T), buf, pos, len, b, Int16(0), Parsers.OPTIONS)
     if code > 0
         return pos, construct(T, x; kw...)
@@ -327,7 +327,7 @@ mutable struct MutableClosure{T, KW}
 end
 
 @inline function (f::MutableClosure)(i, nm, TT; kw...)
-    kw2 = merge(kw, f.kw)
+    kw2 = merge(kw.data, f.kw)
     pos_i, y_i = read(StructType(TT), f.buf, f.pos, f.len, f.b, TT; kw2...)
     f.pos = pos_i
     return y_i
@@ -383,7 +383,7 @@ end
         @eof
         b = getbyte(buf, pos)
         @wh
-        c = MutableClosure(buf, pos, len, b, kw)
+        c = MutableClosure(buf, pos, len, b, kw.data)
         if StructTypes.applyfield!(c, x, key)
             pos = c.pos
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,6 +4,11 @@ function getbyte(buf, pos)
     unsafe_load(pointer(buf.s), pos)
 end
 
+function getbyte(buf::AbstractVector{UInt8}, pos)
+    @inbounds b = buf[pos]
+    return b
+end
+
 macro eof()
     esc(quote
         if pos > len


### PR DESCRIPTION
…llback to Dict merging. Fixes #41

cc: @kmsquire

Here's the benchmark I used, w/ results:
```julia
using JSON3, StructTypes, BenchmarkTools

mutable struct T
    a::Int
    b::Float64
    c::String
    null::Nothing
    maybe::Union{Int, Nothing}
    T() = new()
end

JSON3.StructType(::Type{T}) = JSON3.Mutable()
StructTypes.StructType(::Type{T}) = StructTypes.Mutable()

@btime JSON3.read(b"""
{
    "a": 1,
    "b": 3.14,
    "c": "hey",
    "null": null,
    "maybe": 10
}""", T)

```
Results:
```julia
# master:   4.114 μs (62 allocations: 6.70 KiB)
# 0.1.13:    3.784 μs (16 allocations: 400 bytes)
# this PR:   950.759 ns (11 allocations: 432 bytes)
```