### PR TITLE
Optional serialisation of infinite floats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+Manifest.toml
 docs/build/
 docs/site/
 *.jl.cov

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
 version = "1.0.1"
 
 [deps]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
@@ -21,4 +20,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-

--- a/src/write.jl
+++ b/src/write.jl
@@ -171,8 +171,8 @@ function write(::NumberType, buf, pos, len, y::Integer; kw...)
 end
 
 write(::NumberType, buf, pos, len, x::T; kw...) where {T} = write(NumberType(), buf, pos, len, StructTypes.numbertype(T)(x); kw...)
-function write(::NumberType, buf, pos, len, x::AbstractFloat; kw...)
-    isfinite(x) || error("$x not allowed to be written in JSON spec")
+function write(::NumberType, buf, pos, len, x::AbstractFloat; allow_inf::Bool=false, kw...)
+    isfinite(x) || allow_inf || error("$x not allowed to be written in JSON spec")
     bytes = codeunits(Base.string(x))
     sz = sizeof(bytes)
     @check sz
@@ -183,8 +183,8 @@ function write(::NumberType, buf, pos, len, x::AbstractFloat; kw...)
     return buf, pos, len
 end
 
-@inline function write(::NumberType, buf, pos, len, x::T; kw...) where {T <: Base.IEEEFloat}
-    isfinite(x) || error("$x not allowed to be written in JSON spec")
+@inline function write(::NumberType, buf, pos, len, x::T; allow_inf::Bool=false, kw...) where {T <: Base.IEEEFloat}
+    isfinite(x) || allow_inf || error("$x not allowed to be written in JSON spec")
     @check Parsers.neededdigits(T)
     pos = Parsers.writeshortest(buf, pos, x)
     return buf, pos, len

--- a/test/json.jl
+++ b/test/json.jl
@@ -35,7 +35,7 @@ end
     @test JSON3.write([NaN], allow_inf=true) == "[NaN]"
     @test JSON3.write([Inf], allow_inf=true) == "[Inf]"
     @test JSON3.read("[Inf]", Vector{Float64}) == [Inf]
-    @test JSON3.read("[nan]", Vector{Float64}) == [NaN]
+    @test JSON3.read("[nan]", Vector{Float64})[1] === NaN
 end
 
 @testset "Char" begin

--- a/test/json.jl
+++ b/test/json.jl
@@ -32,6 +32,10 @@ end
 @testset "Floats" begin
     @test_throws ErrorException JSON3.write([NaN])
     @test_throws ErrorException JSON3.write([Inf])
+    @test JSON3.write([NaN], allow_inf=true) == "[NaN]"
+    @test JSON3.write([Inf], allow_inf=true) == "[Inf]"
+    @test JSON3.read("[Inf]", Vector{Float64}) == [Inf]
+    @test JSON3.read("[nan]", Vector{Float64}) == [NaN]
 end
 
 @testset "Char" begin


### PR DESCRIPTION
As mentioned in #49 , sometimes it is desirable to be able to serialise non-finite Floats, despite it being prohibited by JSON spec. This PR is a first stab on this. Reading is handled out of the box by `Parsers.jl`, so all we need to do is allow  writing. This feature is off by default, and is turned on by providing `allow_inf=true` keyword argument to `write`. 

Let me know what you think about this. I have already added some tests, might need to add more (let me know). If you are ok with the general idea, I'll update the tests and the docs.

Another extension would be to allow the old behaviour (also with the keyword arg), where infinite numbers are serialized as `null`s. This might be useful for people who write JSON from Julia which is then consumed by other platforms, so need to stick to the spec and might rely on the `NaN/null`s.
