### PR TITLE
Fix uint8 overflow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "JSON3"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.0.2"
+version = "1.0.3"
 
 [deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [compat]
 Parsers = "0.3, 1"

--- a/src/write.jl
+++ b/src/write.jl
@@ -224,7 +224,7 @@ const ESCAPELENS = [length(x) for x in ESCAPECHARS]
 function escapelength(str)
     x = 0
     @simd for i = 1:ncodeunits(str)
-        @inbounds len = ESCAPELENS[codeunit(str, i) + 0x01]
+        @inbounds len = ESCAPELENS[codeunit(str, i) + 1]
         x += len
     end
     return x
@@ -239,7 +239,7 @@ function write(::StringType, buf, pos, len, x::AbstractString; kw...)
     @inbounds @writechar '"'
     if el > sz
         for i = 1:sz
-            @inbounds escbytes = ESCAPECHARS[codeunit(x, i) + 0x01]
+            @inbounds escbytes = ESCAPECHARS[codeunit(x, i) + 1]
             for j = 1:length(escbytes)
                 @inbounds buf[pos] = escbytes[j]
                 pos += 1

--- a/test/json.jl
+++ b/test/json.jl
@@ -723,3 +723,6 @@ end
 @test JSON3.write([Int64[] Int64[]]') == "[]"
 
 @test Float32(JSON3.read(JSON3.write(2.1f-8))) == 2.1f-8
+
+# PR 60
+@test JSON3.write(String([0xff])) == "\"\xff\""


### PR DESCRIPTION
Fixes #59

The `ESCAPECHARS` and `ESCAPELENS` each have length 256, but whenever we tried to pass in 256, it overflowed to 0, causing some really ugly error since we're using `@inbounds`.

I can add a test with the file that I posted in #59, but I feel something more minimal would be better. Any suggestions?