### PR TITLE
unordered struct reading by default with perf option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/site/
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+.vscode

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -347,6 +347,15 @@ obj = JSON3.read("""
 @test_throws ArgumentError JSON3.read("{\"a\": 1a", A)
 @test_throws ArgumentError JSON3.read("{\"a\": 1, a", A)
 
+objorder = JSON3.read("""
+{ "d": 4,
+  "c": 3,
+  "b": 2,
+  "a": 1
+}
+""", A)
+@test obj == objorder
+
 @test_throws ArgumentError JSON3.read("{}", C)
 @test_throws ArgumentError JSON3.write(C())
 


### PR DESCRIPTION
Possible solution to #69 for discussion - by default switches `StructTypes.Struct()` to a "safe" reader that reads keys and re-orders, with a kwarg `unsafe_struct` that restores the old behavior.

```julia
using StructTypes, JSON3

struct Bar
    a
    b
end
StructTypes.StructType(::Type{Bar}) = JSON3.StructTypes.Struct()

julia> @btime JSON3.read(""" {"b": 1, "a": 2} """, Bar)
  1.250 μs (12 allocations: 352 bytes)
Bar(2, 1)

julia> @btime JSON3.read(""" {"b": 1, "a": 2} """, Bar; unsafe_struct=true)
  326.662 ns (8 allocations: 240 bytes)
Bar(1, 2)
```