### PR TITLE
Use `convert(T, x)` instead of `T(x)`

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -144,7 +144,7 @@ function write(::NullType, buf, pos, len, x; kw...)
     return buf, pos, len
 end
 
-write(::BoolType, buf, pos, len, x; kw...) = write(BoolType(), buf, pos, len, Bool(x); kw...)
+write(::BoolType, buf, pos, len, x; kw...) = write(BoolType(), buf, pos, len, convert(Bool, x); kw...)
 function write(::BoolType, buf, pos, len, x::Bool; kw...)
     if x
         @writechar 't' 'r' 'u' 'e'

--- a/src/write.jl
+++ b/src/write.jl
@@ -144,7 +144,7 @@ function write(::NullType, buf, pos, len, x; kw...)
     return buf, pos, len
 end
 
-write(::BoolType, buf, pos, len, x; kw...) = write(BoolType(), buf, pos, len, convert(Bool, x); kw...)
+write(::BoolType, buf, pos, len, x; kw...) = write(BoolType(), buf, pos, len, StructTypes.construct(Bool, x); kw...)
 function write(::BoolType, buf, pos, len, x::Bool; kw...)
     if x
         @writechar 't' 'r' 'u' 'e'
@@ -171,7 +171,7 @@ function write(::NumberType, buf, pos, len, y::Integer; kw...)
 end
 
 write(::NumberType, buf, pos, len, x::T; kw...) where {T} =
-    write(NumberType(), buf, pos, len, convert(StructTypes.numbertype(T), x); kw...)
+    write(NumberType(), buf, pos, len, StructTypes.construct(StructTypes.numbertype(T), x); kw...)
 function write(::NumberType, buf, pos, len, x::AbstractFloat; allow_inf::Bool=false, kw...)
     isfinite(x) || allow_inf || error("$x not allowed to be written in JSON spec")
     bytes = codeunits(Base.string(x))

--- a/src/write.jl
+++ b/src/write.jl
@@ -170,7 +170,8 @@ function write(::NumberType, buf, pos, len, y::Integer; kw...)
     return buf, pos + n, len
 end
 
-write(::NumberType, buf, pos, len, x::T; kw...) where {T} = write(NumberType(), buf, pos, len, StructTypes.numbertype(T)(x); kw...)
+write(::NumberType, buf, pos, len, x::T; kw...) where {T} =
+    write(NumberType(), buf, pos, len, convert(StructTypes.numbertype(T), x); kw...)
 function write(::NumberType, buf, pos, len, x::AbstractFloat; allow_inf::Bool=false, kw...)
     isfinite(x) || allow_inf || error("$x not allowed to be written in JSON spec")
     bytes = codeunits(Base.string(x))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -294,7 +294,7 @@ x = JSON3.read(str, JSON3.PointerString);
 
 StructTypes.StructType(::Type{XInt}) = StructTypes.NumberType()
 StructTypes.numbertype(::Type{XInt}) = Int64
-Base.Int64(x::XInt) = x.x
+StructTypes.construct(::Type{Int64}, x::XInt) = x.x
 x = XInt(10)
 @test JSON3.read("10", XInt) == x
 @test JSON3.write(x) == "10"


### PR DESCRIPTION
That's the most generic interface, and for `Number` Base provides a fallback definition which calls `T(x)`. So it doesn't require types to implement constructors. Useful for https://github.com/JuliaData/CategoricalArrays.jl/pull/276.