### PR TITLE
RFC: Add the public `read!` function for incrementally updating mutable structs, and add some more tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
-before_install:
-  - cd ../..
-  - mv $TRAVIS_REPO_SLUG _old
-  - git config --global core.autocrlf false
-  - git clone --depth=50 _old $TRAVIS_REPO_SLUG
-  - cd $TRAVIS_REPO_SLUG
+git:
+  autocrlf: false
 
 # Documentation: http://docs.travis-ci.com/user/languages/julia/
 language: julia
@@ -15,10 +11,10 @@ arch:
   - x64
   - x86
 julia:
-  - 1.0
-  - 1
+  - "1.0"
+  - "1"
   - nightly
-matrix:
+jobs:
   allow_failures:
     - julia: nightly
   fast_finish: true
@@ -27,7 +23,7 @@ matrix:
       arch: x86
   include:
     - stage: "Documentation"
-      julia: 1.3
+      julia: "1"
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("JSON3")'
@@ -39,9 +35,8 @@ notifications:
 branches:
   only:
   - master
-  - gh-pages # For building documentation
   - /^testing-.*$/ # testing branches
   - /^v[0-9]+\.[0-9]+\.[0-9]+$/ # version tags
 
 after_success:
-   - julia -e 'ENV["TRAVIS_JULIA_VERSION"] == "1.3" && ENV["TRAVIS_OS_NAME"] != "linux" && exit(); using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'
+   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(Codecov.process_folder())'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSON3"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.2.0"
+version = "1.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/README.md
+++ b/README.md
@@ -20,4 +20,9 @@ JSON3.write(x)
 # custom types
 JSON3.read(json_string, T; kw...)
 JSON3.write(x)
+
+# custom types: incrementally update a mutable struct
+x = T()
+JSON3.read!(json_string, x; kw...)
+JSON3.write(x)
 ```


### PR DESCRIPTION
Fixes #54 

---

Summary:
1. Add the `read!` function
2. Add tests for the `read!` function
3. Add some other tests to keep code coverage up and make Codecov happy
4. Make a few fixes and simplifications in `.travis.yml`
5. Bump the version number in `Project.toml` from `1.2.0` to `1.3.0`

---

This PR adds the public `read!` function for incrementally updating mutable structs.

Example usage:
```julia
x = T()
JSON3.read!(json_string_1, x; kw...)
JSON3.read!(json_string_2, x; kw...)
```

`read!` is only implemented if the struct type of `T` is `StructTypes.Mutable()`. For any other struct type, it will throw a `MethodError`.

This is a non-breaking feature; therefore I have bumped the version number in `Project.toml` from `1.2.0` to `1.3.0`.