### PR TITLE
README: Change Travis badge to point to Travis-CI.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # JSON3.jl
 
-[![Build Status](https://travis-ci.org/quinnj/JSON3.jl.svg?branch=master)](https://travis-ci.org/quinnj/JSON3.jl)
+[![Build Status](https://travis-ci.com/quinnj/JSON3.jl.svg?branch=master)](https://travis-ci.com/quinnj/JSON3.jl)
 [![codecov](https://codecov.io/gh/quinnj/JSON3.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/quinnj/JSON3.jl)
 
 ### Documentation


### PR DESCRIPTION
This repo currently uses Travis-CI.org. Travis-CI.org will shut down on December 31, 2020: https://discourse.julialang.org/t/reminder-travis-ci-org-shuts-down-on-december-31-2020/47234

@quinnj Can you follow the instructions to migrate to Travis-CI.com?

Once you do so, you can merge this PR, which updates the Travis badge in the README to point to Travis-CI.com.