### PR TITLE
Travis: don't allow failures on nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ julia:
   - nightly
 matrix:
   allow_failures:
-    - julia: nightly
+    # - julia: nightly
   fast_finish: true
   exclude:
     - os: osx


### PR DESCRIPTION
This makes it easier to detect any regressions on Julia master/nightly.