### PR TITLE
Introduce a JSON3-specific StructType: RawType

### DIFF
--- a/src/write.jl
+++ b/src/write.jl
@@ -68,6 +68,16 @@ write(::NoStructType, buf, pos, len, ::Type{T}; kw...) where {T} = write(StringT
 
 write(::NoStructType, buf, pos, len, ::T; kw...) where {T} = throw(ArgumentError("$T doesn't have a defined `StructTypes.StructType`"))
 
+function write(::RawType, buf, pos, len, x::T; kw...) where {T}
+    bytes = rawbytes(x)
+    @check length(bytes)
+    for b in bytes
+        @inbounds buf[pos] = b
+        pos += 1
+    end
+    return buf, pos, len
+end
+
 mutable struct WriteClosure{T, KW}
     buf::T
     pos::Int


### PR DESCRIPTION
Proposed solution for #87 and alternative solution to #88.

This PR introduces a new `JSON3.RawType`, which is a `StructType` that
custom types may define as their trait in order to get access to the
"raw value" while parsing. After declaring
`StructTypes.StructType(::Type{MyType}) = JSON3.RawType()`, the custom
`MyType` must also define `StructTypes.construct(::Type{MyType},
x::JSON3.RawValue) = ...`. A `JSON3.RawValue` has 3 fields, `bytes`,
`pos`, and `len`, corresponding to the raw byte buffer, byte position at
which the raw value starts, and the length of the raw value,
respectively. Users are then free to "construct" an instance of their
`MyType` however they want from the `JSON3.RawValue`.

For serializing, i.e. `JSON3.write`, `MyType` must implement a method
like `JSON3.rawbytes(x::MyType) = ...`, which must return an iterator of
bytes (`UInt8`) with known length (`Base.IteratorSize` must be
`Base.HasLength()`). Care must be taken in providing bytes as no
additional processing or escape analysis is done, the bytes are written
"as-is". If bytes are written with unescaped control characters (`'{'`,
`','`, etc.), it will result in corrupt JSON documents.