### PR TITLE
Introduce a JSON3-specific StructType: RawType

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
       os: linux
       script:
         - julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate(); Pkg.build("JSON3")'
+        - julia --project=docs/ -e 'using JSON3; using StructTypes; using Documenter; Documenter.doctest(JSON3)'
         - julia --project=docs/ docs/make.jl
       after_success: skip
 notifications:

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,4 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,4 @@
-using Documenter, JSON3
+using Documenter, JSON3, StructTypes
 
 makedocs(;
     modules=[JSON3],
@@ -9,7 +9,7 @@ makedocs(;
     repo="https://github.com/quinnj/JSON3.jl/blob/{commit}{path}#L{line}",
     sitename="JSON3.jl",
     authors="Jacob Quinn",
-    assets=String[],
+    strict=true,
 )
 
 deploydocs(;

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -226,7 +226,7 @@ respectively. Users are then free to "construct" an instance of their
 For serializing, i.e. `JSON3.write`, `MyType` must implement a method
 like `JSON3.rawbytes(x::MyType) = ...`, which must return an iterator of
 bytes (`UInt8`) with known length (`Base.IteratorSize` must be
-`Base.HasLength()`). Care must be taken in providing bytes as no
+`Base.HasLength()` and `length(JSON3.rawbytes(x))` must work). Care must be taken in providing bytes as no
 additional processing or escape analysis is done, the bytes are written
 "as-is". If bytes are written with unescaped control characters (`'{'`,
 `','`, etc.), it will result in corrupt JSON documents.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ which acts like an immutable `Vector`, but also has a more efficient view repres
 the resulting `JSON3.Array` will be strongly typed accordingly. For the other JSON types (string, number, bool, and null),
 they are returned as Julia equivalents (`String`, `Int64` or `Float64`, `Bool`, and `nothing`).
 
-One might wonder why custom `JSON3.Object` and `JSON3.Array` types exist instead of just returning `Dict` and `Vector` directly. JSON3 employs a novel technique [inspired by the simdjson project](https://github.com/lemire/simdjson), that is a 
+One might wonder why custom `JSON3.Object` and `JSON3.Array` types exist instead of just returning `Dict` and `Vector` directly. JSON3 employs a novel technique [inspired by the simdjson project](https://github.com/lemire/simdjson), that is a
 semi-lazy parsing of JSON to the `JSON3.Object` or `JSON3.Array` types. The technique involves using a type-less "tape" to note
 the *positions* of objects, arrays, and strings in a JSON structure, while avoiding the cost of *materializing* such
 objects. For "scalar" types (number, bool, and null), the values are parsed immediately and stored inline in the "tape". This can result in best of both worlds performance: very fast initial parsing of a JSON input, and very cheap access afterwards. It also enables efficiencies in workflows where only small pieces of a JSON structure are needed, because expensive objects, arrays, and strings aren't materialized unless accessed. One additional advantage this technique allows is strong typing of `JSON3.Array{T}`; because the type of each element is noted while parsing, the `JSON3.Array` object can then be constructed with the most narrow type possible without having to reallocate any underlying data (since all data is stored in a type-less "tape" anyway).
@@ -66,7 +66,7 @@ There are a few additional helper methods that can be utilized by `StructTypes.M
 
 * `StructTypes.names(::Type{MyType}) = ((:field1, :json1), (:field2, :json2))`: provides a mapping of Julia field name to expected JSON object key name. This affects both reading and writing. When reading the `json1` key, the `field1` field of `MyType` will be set. When writing the `field2` field of `MyType`, the JSON key will be `json2`.
 * `StructTypes.excludes(::Type{MyType}) = (:field1, :field2)`: specify fields of `MyType` to ignore when reading and writing, provided as a `Tuple` of `Symbol`s. When reading, if `field1` is encountered as a JSON key, it's value will be read, but the field will not be set in `MyType`. When writing, `field1` will be skipped when writing out `MyType` fields as key-value pairs.
-* `StructTypes.omitempties(::Type{MyType}) = (:field1, :field2)`: specify fields of `MyType` that shouldn't be written if they are "empty", provided as a `Tuple` of `Symbol`s. This only affects writing. If a field is a collection (AbstractDict, AbstractArray, etc.) and `isempty(x) === true`, then it will not be written. If a field is `#undef`, it will not be written. If a field is `nothing`, it will not be written. 
+* `StructTypes.omitempties(::Type{MyType}) = (:field1, :field2)`: specify fields of `MyType` that shouldn't be written if they are "empty", provided as a `Tuple` of `Symbol`s. This only affects writing. If a field is a collection (AbstractDict, AbstractArray, etc.) and `isempty(x) === true`, then it will not be written. If a field is `#undef`, it will not be written. If a field is `nothing`, it will not be written.
 * `StructTypes.keywordargs(::Type{MyType}) = (field1=(dateformat=dateformat"mm/dd/yyyy",), field2=(dateformat=dateformat"HH MM SS",))`: Specify for a `StructTypes.Mutable` `StructType` the keyword arguments by field, given as a `NamedTuple` of `NamedTuple`s, that should be passed
 to the `StructTypes.construct` method when deserializing `MyType`. This essentially allows defining specific keyword arguments you'd like to be passed for each field
 in your struct. Note that keyword arguments can be passed when reading, like `JSON3.read(source, MyType; dateformat=...)` and they will be passed down to each `StructTypes.construct` method.
@@ -82,6 +82,7 @@ StructTypes.StructType(::Type{MyType}) = StructTypes.StringType()
 StructTypes.StructType(::Type{MyType}) = StructTypes.NumberType()
 StructTypes.StructType(::Type{MyType}) = StructTypes.BoolType()
 StructTypes.StructType(::Type{MyType}) = StructTypes.NullType()
+StructTypes.StructType(::Type{MyType}) = JSON3.RawType()
 ```
 
 Now we'll walk through each of these and what it means to map my custom Julia type to an interface type.
@@ -207,6 +208,53 @@ The interface to satisfy for reading is:
   * `StructTypes.construct(::Type{MyType}, x::Nothing; kw...)`: alternatively, you may overload `StructTypes.construct`
 
 There is no interface for writing; if a custom type is declared as `StructTypes.NullType()`, then the JSON value `null` will be written.
+
+#### JSON3.RawType
+
+`JSON3.RawType` is a `StructType` that
+custom types may define as their trait in order to get access to the
+"raw value" while parsing. After declaring
+`StructTypes.StructType(::Type{MyType}) = JSON3.RawType()`, the custom
+`MyType` must also define
+`StructTypes.construct(::Type{MyType}, x::JSON3.RawValue) = ...`. A
+`JSON3.RawValue` has 3 fields, `bytes`,
+`pos`, and `len`, corresponding to the raw byte buffer, byte position at
+which the raw value starts, and the length of the raw value,
+respectively. Users are then free to "construct" an instance of their
+`MyType` however they want from the `JSON3.RawValue`.
+
+For serializing, i.e. `JSON3.write`, `MyType` must implement a method
+like `JSON3.rawbytes(x::MyType) = ...`, which must return an iterator of
+bytes (`UInt8`) with known length (`Base.IteratorSize` must be
+`Base.HasLength()`). Care must be taken in providing bytes as no
+additional processing or escape analysis is done, the bytes are written
+"as-is". If bytes are written with unescaped control characters (`'{'`,
+`','`, etc.), it will result in corrupt JSON documents.
+
+For example, suppose that you want to read a JSON number verbatim into a
+Julia string:
+```jldoctest
+julia> using JSON3, StructTypes
+
+julia> struct StringNumber
+       value::String
+       end
+
+julia> @inline StructTypes.StructType(::Type{StringNumber}) = JSON3.RawType()
+
+julia> @inline StructTypes.construct(::Type{StringNumber}, x::JSON3.RawValue) = StringNumber(unsafe_string(pointer(x.bytes, x.pos), x.len))
+
+julia> @inline JSON3.rawbytes(x::StringNumber) = codeunits(x.value)
+
+julia> j = "1.200"
+"1.200"
+
+julia> x = JSON3.read(j, StringNumber)
+StringNumber("1.200")
+
+julia> JSON3.write(x)
+"1.200"
+```
 
 ### AbstractTypes
 

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -62,7 +62,7 @@ end
 
 const GLOBAL_IGNORED_TAPE = zeros(UInt64, 1024)
 
-function read(::RawType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+@inline function read(::RawType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     newpos, _ = read!(buf, pos, len, b, GLOBAL_IGNORED_TAPE, 1, Any; kw...)
     return newpos, construct(T, RawValue(buf, pos, newpos - pos))
 end

--- a/src/write.jl
+++ b/src/write.jl
@@ -68,7 +68,7 @@ write(::NoStructType, buf, pos, len, ::Type{T}; kw...) where {T} = write(StringT
 
 write(::NoStructType, buf, pos, len, ::T; kw...) where {T} = throw(ArgumentError("$T doesn't have a defined `StructTypes.StructType`"))
 
-function write(::RawType, buf, pos, len, x::T; kw...) where {T}
+@inline function write(::RawType, buf, pos, len, x::T; kw...) where {T}
     bytes = rawbytes(x)
     @check length(bytes)
     for b in bytes
@@ -267,4 +267,3 @@ function write(::StringType, buf, pos, len, x::AbstractString; kw...)
 end
 
 write(::StringType, buf, pos, len, x::Symbol; kw...) = write(StringType(), buf, pos, len, String(x); kw...)
-

--- a/src/write.jl
+++ b/src/write.jl
@@ -68,6 +68,16 @@ write(::NoStructType, buf, pos, len, ::Type{T}; kw...) where {T} = write(StringT
 
 write(::NoStructType, buf, pos, len, ::T; kw...) where {T} = throw(ArgumentError("$T doesn't have a defined `StructTypes.StructType`"))
 
+function write(::RawType, buf, pos, len, x::T; kw...) where {T}
+    bytes = rawbytes(x)
+    @check length(bytes)
+    for b in bytes
+        @inbounds buf[pos] = b
+        pos += 1
+    end
+    return buf, pos, len
+end
+
 mutable struct WriteClosure{T, KW}
     buf::T
     pos::Int

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -799,3 +799,5 @@ JSON3.pretty(io,  JSON3.write(Dict( "x" => Inf64), allow_inf=true), allow_inf=tr
 @test JSON3.read("{\"a\":\"10\",\"b\":\"1\",\"c\":\"45\",\"d\":\"100\"}", A; parsequoted=true) == A(10, 1, 45, 100)
 
 end # @testset "JSON3"
+
+include("stringnumber.jl")

--- a/test/stringnumber.jl
+++ b/test/stringnumber.jl
@@ -1,0 +1,112 @@
+using JSON3
+using StructTypes
+using Test
+
+struct StringNumber
+    value::String
+end
+
+@inline Base.getindex(x::StringNumber) = x.value::String
+
+@inline StructTypes.StructType(::Type{StringNumber}) = JSON3.RawType()
+@inline StructTypes.construct(::Type{StringNumber}, x::JSON3.RawValue) = StringNumber(unsafe_string(pointer(x.bytes, x.pos), x.len))
+@inline JSON3.rawbytes(x::StringNumber) = codeunits(x.value)
+
+@inline function test_roundtrip(json::String, object, ::Type{T}) where T
+    # starting with object
+    a = JSON3.write(object)
+    @test typeof(a) === String
+    b = JSON3.read(a, T)
+    @test typeof(b) === typeof(object)
+    c = JSON3.write(b)
+    @test typeof(c) === String
+    @test a === c
+
+    # starting with json
+    a = JSON3.read(json, T)
+    @test typeof(a) == T
+    @test typeof(a) == typeof(object)
+    mutable_struct_equality(a, object)
+    b = JSON3.write(a)
+    @test typeof(b) === String
+    @test b === json
+
+    # @test false
+
+    return nothing
+end
+
+@inline function mutable_struct_equality(a::T, b::T)::Bool where T
+    if isstructtype(T) && T.mutable
+        T_fieldnames = fieldnames(T)
+        T_num_fieldnames = length(T_fieldnames)
+        temp_vector = Vector{Bool}(undef, T_num_fieldnames)
+        for i in 1:T_num_fieldnames
+            name_i = T_fieldnames[i]
+            temp_vector[i] = mutable_struct_equality(getfield(a, name_i), getfield(b, name_i))
+        end
+        return all(temp_vector)
+    else
+        return a == b
+    end
+end
+
+mutable struct StringNumberTests_A{S}
+    entries::Vector{S}
+    StringNumberTests_A{S}()        where {S} = new{S}()
+    StringNumberTests_A{S}(entries) where {S} = new{S}(entries)
+end
+mutable struct StringNumberTests_B{T}
+    foo::T
+    StringNumberTests_B{T}()    where {T} = new{T}()
+    StringNumberTests_B{T}(foo) where {T} = new{T}(foo)
+end
+mutable struct StringNumberTests_C
+    bar::StringNumber
+    StringNumberTests_C() = new()
+    StringNumberTests_C(bar) = new(bar)
+end
+StructTypes.StructType(::Type{<:StringNumberTests_A}) = StructTypes.Mutable()
+StructTypes.StructType(::Type{<:StringNumberTests_B}) = StructTypes.Mutable()
+StructTypes.StructType(::Type{<:StringNumberTests_C}) = StructTypes.Mutable()
+
+@testset "JSON3.RawType: StringNumber" begin
+    @testset "Basic tests" begin
+        test_cases = ["1.2", "1.20", "1.200", "1.2000", "1.20000"]
+        @testset "Reading" begin
+            for a in test_cases
+                b = JSON3.read(a, StringNumber)
+                @test typeof(b) === StringNumber
+                @test typeof(b[]) === String
+                @test b[] === a
+            end
+        end
+        @testset "Writing" begin
+            for c in test_cases
+                d = StringNumber(c)
+                e = JSON3.write(d)
+                @test typeof(e) === String
+                @test e === c
+            end
+        end
+        @testset "Roundtrip" begin
+            for json in test_cases
+                object = StringNumber(json)
+                test_roundtrip(json, object, StringNumber)
+            end
+        end
+    end
+    @testset "More complex test" begin
+        a = StringNumber("1.20")
+        b = StringNumber("34.5600")
+        c = StringNumberTests_C(a)
+        d = StringNumberTests_C(b)
+        e = StringNumberTests_B{StringNumberTests_C}(c)
+        f = StringNumberTests_B{StringNumberTests_C}(d)
+        g = [e, f]
+        object = StringNumberTests_A{StringNumberTests_B{StringNumberTests_C}}(g)
+        json = "{\"entries\":[{\"foo\":{\"bar\":1.20}},{\"foo\":{\"bar\":34.5600}}]}"
+        T = StringNumberTests_A{StringNumberTests_B{StringNumberTests_C}}
+        test_roundtrip(json, object, T)
+    end
+end


### PR DESCRIPTION
Fixes #87
Closes #88
Closes #89

This pull request adds docs, tests, and examples to #89.

Quoting @quinnj in the original PR (#89):

> This PR introduces a new `JSON3.RawType`, which is a `StructType` that
> custom types may define as their trait in order to get access to the
> "raw value" while parsing. After declaring
> `StructTypes.StructType(::Type{MyType}) = JSON3.RawType()`, the custom
> `MyType` must also define `StructTypes.construct(::Type{MyType}, x::JSON3.RawValue) = ...`. A `JSON3.RawValue` has 3 fields, `bytes`,
> `pos`, and `len`, corresponding to the raw byte buffer, byte position at
> which the raw value starts, and the length of the raw value,
> respectively. Users are then free to "construct" an instance of their
> `MyType` however they want from the `JSON3.RawValue`.
> 
> For serializing, i.e. `JSON3.write`, `MyType` must implement a method
> like `JSON3.rawbytes(x::MyType) = ...`, which must return an iterator of
> bytes (`UInt8`) with known length (`Base.IteratorSize` must be
> `Base.HasLength()`). Care must be taken in providing bytes as no
> additional processing or escape analysis is done, the bytes are written
> "as-is". If bytes are written with unescaped control characters (`'{'`,
> `','`, etc.), it will result in corrupt JSON documents.