### PR TITLE
Remove the need for a subtype key if `StructTypes.subtypes` has length one

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSON3"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.4.0"
+version = "1.5.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -552,6 +552,15 @@ end
 end
 
 @inline function read(::AbstractType, buf, pos, len, b, ::Type{T}; kw...) where {T}
+    types = subtypes(T)
+    if length(types) == 1
+        only_subtype = types[1]
+        return read(StructType(only_subtype), buf, pos, len, b, only_subtype; kw...)
+    end
+    return _read(AbstractType(), buf, pos, len, b, T; kw...)
+end
+
+@inline function _read(::AbstractType, buf, pos, len, b, ::Type{T}; kw...) where {T}
     startpos = pos
     startb = b
     if b != UInt8('{')

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,16 @@ struct Truck <: Vehicle
     payloadCapacity::Float64
 end
 
+abstract type Vehicle2 end
+
+mutable struct Car2 <: Vehicle2
+    make::String
+    model::String
+    seatingCapacity::Int
+    topSpeed::Float64
+    Car2() = new()
+end
+
 abstract type Expression end
 
 abstract type Literal <: Expression end
@@ -615,6 +625,22 @@ truck = JSON3.read("""
 @test_throws ArgumentError JSON3.read("{\"a\": 1a", Vehicle)
 @test_throws ArgumentError JSON3.read("{\"a\": 1, a", Vehicle)
 @test_throws ArgumentError JSON3.read("{\"a\": 1}", Vehicle)
+
+StructTypes.StructType(::Type{Vehicle2}) = StructTypes.AbstractType()
+StructTypes.subtypes(::Type{Vehicle2}) = (Car2=Car2,)
+StructTypes.StructType(::Type{Car2}) = StructTypes.Mutable()
+car2 = JSON3.read("""
+{
+    "topSpeed": 250.1,
+    "model": "S500",
+    "make": "Mercedes-Benz",
+    "seatingCapacity": 5
+}""", Vehicle2)
+
+@test typeof(car2) == Car2
+@test car2.make == "Mercedes-Benz"
+@test car2.topSpeed === 250.1
+@test JSON3.write(car2) == "{\"make\":\"Mercedes-Benz\",\"model\":\"S500\",\"seatingCapacity\":5,\"topSpeed\":250.1}"
 
 StructTypes.StructType(::Type{Expression}) = StructTypes.AbstractType()
 StructTypes.subtypes(::Type{Expression}) = (AND=AndFunction, LITERAL=LiteralValue)


### PR DESCRIPTION
This PR makes the following changes:
1. New feature: Removes the need for a subtype key if `StructTypes.subtypes` has length one
2. Bumps the version number in `Project.toml` from `1.4.0` to `1.5.0`

### Fixes the following issues:

Fixes #93 