### PR TITLE
Ensure with allow_inf=false, we don't parse `-Inf` as valid

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -65,6 +65,7 @@ function read!(buf, pos, len, b, tape, tapeidx, ::Type{Any}, checkint=true; allo
     elseif (UInt8('0') <= b <= UInt8('9')) || b == UInt8('-') || b == UInt8('+') || (allow_inf && (b == UInt8('N') || b == UInt8('I')))
         float, code, floatpos = Parsers.typeparser(Float64, buf, pos, len, b, Int16(0), Parsers.OPTIONS)
         if code > 0
+            !isfinite(float) && !allow_inf && @goto invalid
             @check
             if checkint
                 int = unsafe_trunc(Int64, float)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -818,6 +818,9 @@ x = JSON3.read(json; jsonlines=true)
 @test length(x) == 2
 @test x == [1, 2]
 
+# allow_inf consistency
+@test_throws ArgumentError JSON3.read("-Infinity")
+
 end # @testset "JSON3"
 
 include("stringnumber.jl")


### PR DESCRIPTION
There was an inconsistency where parsing `Inf` threw an error but
parsing `-Inf` didn't, because parsing first looked at `-` then parsed a
Float64 and detected it was valid. We need an extra check after float
parsing to ensure that if `allow_inf=false`, that our answer `isfinite`.
Reported in https://github.com/quinnj/JSON3.jl/pull/103.