### PR TITLE
Test on macOS and Windows (in addition to Linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,10 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
-          - windows-latest
+          include:
+          - os: windows-latest
+            version: '1'
+            arch: x86
         arch:
           - x64
     steps:


### PR DESCRIPTION
Right now, the GitHub Actions CI is only being run on Linux.

I figured it would be nice to also test the package on macOS and Windows.

cc: @quinnj 