### PR TITLE
Add dedicated tape index lookup for Object/Array

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,8 +22,7 @@ objects. For "scalar" types (number, bool, and null), the values are parsed imme
 
 The `JSON3.Object` supports the `AbstactDict` interface, but is read-only (it represents a *view* into the JSON string input), thus it supports `obj[:x]` and `obj["x"]`, as well as `obj.x` for accessing fields. It supports `keys(obj)` to see available keys in the object structure. You can call `length(obj)` to see how many key-value pairs there are, and it iterates `(k, v)` pairs like a normal `Dict`. It also supports the regular `get(obj, key, default)` family of methods. PLEASE NOTE that iterating key-value pairs from `JSON3.Object` will be much more performant than calling `getindex` or `get`on each key due to the internal "view" nature of the object.
 
-The `JSON3.Array{T}` supports the `AbstractArray` interface, but like `JSON3.Object` is a *view* into the input JSON, hence is read-only. It supports normal array methods like `length(A)`, `size(A)`, iteration, and `A[i]` `getindex` methods. PLEASE NOTE that iterating a `JSON3.Array` will be much more performant than calling `getindex` on
-each index due to the internal "view" nature of the array.
+The `JSON3.Array{T}` supports the `AbstractArray` interface, but like `JSON3.Object` is a *view* into the input JSON, hence is read-only. It supports normal array methods like `length(A)`, `size(A)`, iteration, and `A[i]` `getindex` methods.
 
 If you really need `Dict`s and `Vector`s, then you can use `copy(x)` to recursively convert `JSON3.Object`s to `Dict`s and `JSON3.Array`s to `Vector`s.
 

--- a/src/read.jl
+++ b/src/read.jl
@@ -29,9 +29,13 @@ function read(str::AbstractString; jsonlines::Bool=false, kw...)
     end
     @inbounds t = tape[1]
     if isobject(t)
-        return Object(buf, tape)
+        obj = Object(buf, tape, Dict{Symbol, Int}())
+        populateinds!(obj)
+        return obj
     elseif isarray(t)
-        return Array{geteltype(tape[2])}(buf, tape)
+        arr = Array{geteltype(tape[2])}(buf, tape, Int[])
+        populateinds!(arr)
+        return arr
     else
         return getvalue(Any, buf, tape, 1, t)
     end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -110,8 +110,17 @@ regularstride(T) = false
 regularstride(::Union{Type{Int64}, Type{Float64}, Type{Bool}, Type{Nothing}}) = true
 regularstride(::Type{Union{Int64, Float64}}) = true
 
-getvalue(::Type{Object}, buf, tape, tapeidx, t) = Object(buf, Base.unsafe_view(tape, tapeidx:tapeidx + getnontypemask(t)))
-getvalue(::Type{Array}, buf, tape, tapeidx, t) = Array{geteltype(tape[tapeidx+1])}(buf, Base.unsafe_view(tape, tapeidx:tapeidx + getnontypemask(t)))
+function getvalue(::Type{Object}, buf, tape, tapeidx, t)
+    x = Object(buf, Base.unsafe_view(tape, tapeidx:tapeidx + getnontypemask(t)), Dict{Symbol, Int}())
+    populateinds!(x)
+    return x
+end
+
+function getvalue(::Type{Array}, buf, tape, tapeidx, t)
+    x = Array{geteltype(tape[tapeidx+1])}(buf, Base.unsafe_view(tape, tapeidx:tapeidx + getnontypemask(t)), Int[])
+    populateinds!(x)
+    return x
+end
 
 function getvalue(::Type{Symbol}, buf, tape, tapeidx, t)
     @inbounds t2 = tape[tapeidx + 1]


### PR DESCRIPTION
Fixes https://github.com/quinnj/JSON3.jl/issues/117. We originally relied solely on the tape + tape index lookup to retrieve a specific value for `JSON3.Object`/`JSON3.Array`. There are too many ways to get "bitten" by this, however, so I'm personally in favor of the slight extra cost of populating these `inds` fields on the structs, which is negligible on larger objects/arrays, in order to improve random access performance.