### PR TITLE
Generate types from JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,8 @@ open("my.json", "w") do f
     JSON3.pretty(f, JSON3.write(x))
     println(f)
 end
+
+# generate a type from json, requires StructTypes be installed
+JSON3.@generatetypes json_string_sample
+JSON3.read(json_string, JSONTypes.Root)
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -317,3 +317,37 @@ x = MyParametricType(1)
 StructTypes.StructType(::Type{<:MyParametricType}) = StructTypes.Struct() # note the `<:`
                                                               # NOT like this StructTypes.StructType(::Type{MyParametricType})
 ```
+
+## Generated Types
+
+JSON3 has the ability to generate types from sample JSON, which then can be used to parse JSON into. Inspired by the [F# type provider](http://tomasp.net/academic/papers/fsharp-data/fsharp-data.pdf).
+
+```julia
+JSON3.@generatetypes sample :MyModule
+JSON3.read(full_json, MyModule.Root)
+```
+
+The [`JSON3.@generatetypes`](@ref) macro takes a JSON string or file name, generates a raw type from it, then parses that raw type into a series of mutable structs, which are then evaluated in a module (default `JSONTypes`) in the local scope.  Alternately, the [`JSON3.writetypes`](@ref) function can be used to perform these same steps, but instead write the generated module to file.
+
+```julia
+# writes a module called JSONTypes with the root struct Root as mutable
+JSON3.writetypes(sample, "json_types.jl")
+
+# write the same module, but with custom names and immutable
+JSON3.writetypes(sample, "json_types.jl"; module_name=:MyModule, root_name=:ABC, mutable=false)
+
+# these files can then be edited as needed (perhaps to prune the imported json)
+include("json_types.jl")
+```
+
+### API
+
+```@docs
+JSON3.generatetypes
+JSON3.@generatetypes
+JSON3.writetypes
+JSON3.generate_type
+JSON3.generate_exprs
+JSON3.write_exprs
+JSON3.generate_struct_type_module
+```

--- a/src/JSON3.jl
+++ b/src/JSON3.jl
@@ -163,5 +163,6 @@ include("show.jl")
 include("structs.jl")
 include("write.jl")
 include("pretty.jl")
+include("gentypes.jl")
 
 end # module

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -1,5 +1,5 @@
 @static if Base.VERSION < v"1.2"
-    function hasfield(::Type{T}, name::Symbol) where T
+    function hasfield(::Type{T}, name::Symbol) where {T}
         return name in fieldnames(T)
     end
     fieldtypes(::Type{T}) where {T} = Tuple(fieldtype(T, i) for i = 1:fieldcount(T))
@@ -21,30 +21,40 @@ function unify(
     a::Type{NamedTuple{A,T}},
     b::Type{NamedTuple{B,S}},
 ) where {A,T<:Tuple,B,S<:Tuple}
-    c = Dict()
+    ks = []
+    ts = []
     for (k, v) in zip(A, fieldtypes(a))
-        c[k] = unify(v, get_type(b, k))
+        push!(ks, k)
+        push!(ts, unify(v, get_type(b, k)))
     end
 
     for (k, v) in zip(B, fieldtypes(b))
-        if !haskey(c, k)
-            c[k] = unify(v, Nothing)
+        if !(k in ks)
+            push!(ks, k)
+            push!(ts, unify(v, Nothing))
         end
     end
 
-    return NamedTuple{tuple(keys(c)...),Tuple{values(c)...}}
+    return NamedTuple{tuple(ks...),Tuple{ts...}}
 end
 
 unify(a::Type{Vector{T}}, b::Type{Vector{S}}) where {T,S} = Vector{unify(T, S)}
 
-# parse json into a type
+# parse json into a type, maintain field order
+"""
+    generate_type(json)
+
+Given a JSON3 Object or Array, return a "raw type" from it.  A raw type is typically a `NamedTuple`, which can contain further nested `NamedTuples`, concrete, `Array`, or `Union` types.
+"""
 function generate_type(o::JSON3.Object)
-    d = Dict()
+    ks = []
+    ts = []
     for (k, v) in o
-        d[k] = generate_type(v)
+        push!(ks, k)
+        push!(ts, generate_type(v))
     end
 
-    return NamedTuple{tuple(keys(d)...),Tuple{values(d)...}}
+    return NamedTuple{tuple(ks...),Tuple{ts...}}
 end
 
 function generate_type(a::JSON3.Array)
@@ -100,48 +110,86 @@ function pascalcase(s::Symbol)
     return Symbol(new_str)
 end
 
-# write the structs to file
+"""
+    write_exprs(expr, f)
+
+Write an `Expr` or `Vector{Expr}` to file.  Formatted so that it can be used with `include`.
+"""
+function write_exprs(expr::Expr, io::IOStream)
+    str = repr(expr)[3:end-1] # removes :( and )
+    str = replace(str, "\n  " => "\n") # un-tab each line
+    Base.write(io, str)
+    Base.write(io, "\n\n")
+end
+
 function write_exprs(exprs::Vector, fname::AbstractString)
     open(fname, "w") do io
         for expr in exprs
-            str = repr(expr)[3:end-1] # removes :( and )
-            str = replace(str, "\n  " => "\n") # un-tab each line
-            Base.write(io, str)
-            Base.write(io, "\n\n")
+            write_exprs(expr, io)
         end
     end
 end
 
+function write_exprs(expr::Expr, fname::AbstractString)
+    open(fname, "w") do io
+        write_exprs(expr, io)
+    end
+end
+
 # entry function for turning a "raw" type from `generate_type` to Exprs
-function generate_exprs(t, name::Symbol=:Root)
+"""
+    generate_exprs(raw_type, name=:Root; mutable=true)
+
+Generate a vector of `Expr` from a "raw_type".  This will un-nest any sub-types within the root type.
+
+The name of the root type is from the `name` variable (default :Root), then nested types are named from the key that they live under in the JSON.  The key is transformed to be pascal case and singular.
+
+If `mutable` is `true`, an empty constructor is included in the struct definition. This allows the mutable structs to be used with `StructTypes.Mutable()` out of the box.
+"""
+function generate_exprs(t, name::Symbol = :Root; mutable = true)
     exprs = []
-    generate_expr!(exprs, t, name)
+    generate_expr!(exprs, t, name; mutable = mutable)
     return exprs
 end
 
 # turn a "raw" type into an AST for a struct
-function generate_expr!(exprs, nt::Type{NamedTuple{N,T}}, root_name::Symbol) where {N,T<:Tuple}
+function generate_expr!(
+    exprs,
+    nt::Type{NamedTuple{N,T}},
+    root_name::Symbol;
+    mutable::Bool = true,
+) where {N,T<:Tuple}
     sub_exprs = []
     for (n, t) in zip(N, fieldtypes(nt))
-        push!(sub_exprs, generate_field_expr!(exprs, t, n))
+        push!(sub_exprs, generate_field_expr!(exprs, t, n; mutable = mutable))
     end
+
     struct_name = pascalcase(root_name)
-    push!(exprs, Expr(:struct, false, struct_name, Expr(:block, sub_exprs...)))
+    if mutable
+        push!(sub_exprs, Meta.parse("$struct_name() = new()"))
+    end
+
+    push!(exprs, Expr(:struct, mutable, struct_name, Expr(:block, sub_exprs...)))
     return struct_name
 end
 
 # should only hit this in the case of the array being the root of the type
-function generate_expr!(exprs, ::Type{Base.Array{T,N}}, root_name::Symbol) where {T<:NamedTuple,N}
-    return generate_expr!(exprs, T, root_name)
+function generate_expr!(
+    exprs,
+    ::Type{Base.Array{T,N}},
+    root_name::Symbol;
+    kwargs...,
+) where {T<:NamedTuple,N}
+    return generate_expr!(exprs, T, root_name; kwargs...)
 end
 
-function generate_expr!(exprs, t::Type{T}, root_name::Symbol) where {T}
+function generate_expr!(exprs, t::Type{T}, root_name::Symbol; kwargs...) where {T}
     if T isa Union
         return Expr(
             :curly,
             :Union,
-            generate_expr!(exprs, t.a, root_name),
-            generate_expr!(exprs, t.b, root_name),
+            generate_expr!(exprs, t.a, root_name; kwargs...),
+            generate_expr!(exprs, t.b, root_name; kwargs...),
         )
     else
         return to_ast(T)
@@ -149,33 +197,117 @@ function generate_expr!(exprs, t::Type{T}, root_name::Symbol) where {T}
 end
 
 # given the type of a field of a struct, return a node for that field's name/type
-function generate_field_expr!(exprs, t::Type{NamedTuple{N,T}}, root_name::Symbol) where {N,T}
-    generate_expr!(exprs, t, root_name)
+function generate_field_expr!(
+    exprs,
+    t::Type{NamedTuple{N,T}},
+    root_name::Symbol;
+    kwargs...,
+) where {N,T}
+    generate_expr!(exprs, t, root_name; kwargs...)
     return Expr(:(::), root_name, pascalcase(root_name))
 end
 
-function generate_field_expr!(exprs, ::Type{Base.Array{T,N}}, root_name::Symbol) where {T,N}
-    return Expr(:(::), root_name, Expr(:curly, :Array, generate_expr!(exprs, T, root_name), 1))
+function generate_field_expr!(
+    exprs,
+    ::Type{Base.Array{T,N}},
+    root_name::Symbol;
+    kwargs...,
+) where {T,N}
+    return Expr(
+        :(::),
+        root_name,
+        Expr(:curly, :Array, generate_expr!(exprs, T, root_name; kwargs...), 1),
+    )
 end
 
-function generate_field_expr!(exprs, ::Type{T}, root_name::Symbol) where {T}
-    return Expr(:(::), root_name, generate_expr!(exprs, T, root_name))
+function generate_field_expr!(exprs, ::Type{T}, root_name::Symbol; kwargs...) where {T}
+    return Expr(:(::), root_name, generate_expr!(exprs, T, root_name; kwargs...))
 end
 
+# create a module with the struct declarations as well as the StructType declarations
+"""
+    generate_struct_type_module(exprs, module_name)
 
-macro generatetypes(json_str, name)
+Given a vector of `exprs` (output of [`generate_exprs`](@ref)), return an `Expr` containing the AST for a module with name `module_name`.  The module will map all types to the appropriate `StructType`, so the result can immediately used with `JSON3.read(json, T)`.
+"""
+function generate_struct_type_module(exprs, module_name)
+    mutable = exprs[1].args[1]
+    struct_type_import = Meta.parse("import StructTypes")
+    struct_type = mutable ? "Mutable" : "Struct"
+    struct_type_decls = []
+    for expr in exprs
+        push!(
+            struct_type_decls,
+            Meta.parse("StructTypes.StructType(::Type{$(expr.args[2])}) = StructTypes.$struct_type()"),
+        )
+    end
+    type_block = Expr(:block, struct_type_import, exprs..., struct_type_decls...)
+    return Expr(:module, true, module_name, type_block)
+end
+
+"""
+    generatetypes(json, module_name; mutable=true, root_name=:Root)
+
+Convenience function to go from a json string or file name to an AST with a module of structs.
+
+Performs the following:
+1. If the JSON is a file, read to string
+2. Call `JSON3.read` on the JSON string
+3. Get the "raw type" from [`generate_type`](@ref)
+4. Parse the "raw type" into a vector of `Expr` ([`generate_exprs`](@ref))
+5. Generate a module containg the structs ([`generate_struct_type_module`](@ref))
+"""
+function generatetypes(
+    json_str::AbstractString,
+    module_name::Symbol;
+    mutable::Bool = true,
+    root_name::Symbol = :Root,
+)
+    # either a JSON.Array or JSON.Object
+    json = read(
+        length(json_str) < 255 && isfile(json_str) ? Base.read(json_str, String) :
+            json_str,
+    )
+
+    # build a type for the JSON
+    raw_json_type = generate_type(json)
+    json_exprs = generate_exprs(raw_json_type, root_name)
+    return generate_struct_type_module(
+        json_exprs,
+        module_name
+    )
+end
+
+# macro to create a module with types generated from a json string
+"""
+    @generatetypes json [module_name]
+
+Evaluate the result of the [`generatetypes`](@ref) function in the current scope.
+"""
+macro generatetypes(json_str, module_name)
     return quote
-        # either a JSON.Array or JSON.Object
-        local json = JSON3.read(length($(esc(json_str))) < 255 && isfile($(esc(json_str))) ? read($(esc(json_str))) : $(esc(json_str)))
-
-        # build a type for the JSON
-        local raw_json_type = JSON3.generate_type(json)
-        local json_exprs = JSON3.generate_exprs(raw_json_type, $(esc(name)))
-        local exprs = Expr(:block, json_exprs...)
-        return Core.eval($__module__, exprs)
+        local mod = JSON3.generatetypes($(esc(json_str)), $(esc(module_name)))
+        return Core.eval($__module__, mod)
     end
 end
 
 macro generatetypes(json)
-    :(@generatetypes $(esc(json)) :Root)
+    :(@generatetypes $(esc(json)) :JSONTypes)
+end
+
+# convenience function to go from json_string, to file with module
+"""
+    writetypes(json, file_name; module_name=:JSONTypes, root_name=:Root, mutable=true)
+
+Write the result of the [`generatetypes`](@ref) function to file.
+"""
+function writetypes(
+    json,
+    file_name;
+    module_name::Symbol = :JSONTypes,
+    root_name = :Root,
+    mutable::Bool = true,
+)
+    mod = generatetypes(json, module_name)
+    write_exprs(mod, file_name)
 end

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -1,0 +1,181 @@
+@static if Base.VERSION < v"1.2"
+    function hasfield(::Type{T}, name::Symbol) where T
+        return name in fieldnames(T)
+    end
+    fieldtypes(::Type{T}) where {T} = Tuple(fieldtype(T, i) for i = 1:fieldcount(T))
+end
+
+# top type - unifying a type with top yeilds the type
+struct Top end
+
+# get the type from a named tuple, given a name
+get_type(NT, k) = hasfield(NT, k) ? fieldtype(NT, k) : Nothing
+
+# unify two types to a single type
+unify(a, b) = unify(b, a)
+unify(a::Type{T}, b::Type{S}) where {T,S} = Base.promote_typejoin(T, S)
+unify(a::Type{T}, b::Type{S}) where {T,S<:T} = T
+unify(a::Type{Top}, b::Type{T}) where {T} = T
+
+function unify(
+    a::Type{NamedTuple{A,T}},
+    b::Type{NamedTuple{B,S}},
+) where {A,T<:Tuple,B,S<:Tuple}
+    c = Dict()
+    for (k, v) in zip(A, fieldtypes(a))
+        c[k] = unify(v, get_type(b, k))
+    end
+
+    for (k, v) in zip(B, fieldtypes(b))
+        if !haskey(c, k)
+            c[k] = unify(v, Nothing)
+        end
+    end
+
+    return NamedTuple{tuple(keys(c)...),Tuple{values(c)...}}
+end
+
+unify(a::Type{Vector{T}}, b::Type{Vector{S}}) where {T,S} = Vector{unify(T, S)}
+
+# parse json into a type
+function generate_type(o::JSON3.Object)
+    d = Dict()
+    for (k, v) in o
+        d[k] = generate_type(v)
+    end
+
+    return NamedTuple{tuple(keys(d)...),Tuple{values(d)...}}
+end
+
+function generate_type(a::JSON3.Array)
+    t = Set([])
+    nt = Top
+    for item in a
+        it = generate_type(item)
+        if it <: NamedTuple
+            nt = unify(nt, it)
+        else
+            push!(t, it)
+        end
+    end
+
+    return Vector{foldl(unify, t; init = Union{nt})}
+end
+
+generate_type(x::T) where {T} = T
+
+# get the AST of a type
+function to_ast(::Type{T}) where {T}
+    io = IOBuffer()
+    print(io, T)
+    str = String(take!(io))
+    ast = Meta.parse(str)
+    return ast
+end
+
+# make a field identifer into pascal case for struct name (my_name => MyName)
+function pascalcase(s::Symbol)
+    str = String(s)
+    new_str = ""
+    next_upper = true
+    for letter in str
+        if next_upper
+            new_str *= uppercase(letter)
+            next_upper = false
+        elseif letter == '_'
+            next_upper = true
+        else
+            new_str *= letter
+        end
+    end
+
+    if new_str[end] == 's'
+        if new_str[end-2:end] == "ies"
+            new_str = new_str[1:end-3] * "y"
+        else
+            new_str = new_str[1:end-1]
+        end
+    end
+
+    return Symbol(new_str)
+end
+
+# write the structs to file
+function write_exprs(exprs::Vector, fname::AbstractString)
+    open(fname, "w") do io
+        for expr in exprs
+            str = repr(expr)[3:end-1] # removes :( and )
+            str = replace(str, "\n  " => "\n") # un-tab each line
+            Base.write(io, str)
+            Base.write(io, "\n\n")
+        end
+    end
+end
+
+# entry function for turning a "raw" type from `generate_type` to Exprs
+function generate_exprs(t, name::Symbol=:Root)
+    exprs = []
+    generate_expr!(exprs, t, name)
+    return exprs
+end
+
+# turn a "raw" type into an AST for a struct
+function generate_expr!(exprs, nt::Type{NamedTuple{N,T}}, root_name::Symbol) where {N,T<:Tuple}
+    sub_exprs = []
+    for (n, t) in zip(N, fieldtypes(nt))
+        push!(sub_exprs, generate_field_expr!(exprs, t, n))
+    end
+    struct_name = pascalcase(root_name)
+    push!(exprs, Expr(:struct, false, struct_name, Expr(:block, sub_exprs...)))
+    return struct_name
+end
+
+# should only hit this in the case of the array being the root of the type
+function generate_expr!(exprs, ::Type{Base.Array{T,N}}, root_name::Symbol) where {T<:NamedTuple,N}
+    return generate_expr!(exprs, T, root_name)
+end
+
+function generate_expr!(exprs, t::Type{T}, root_name::Symbol) where {T}
+    if T isa Union
+        return Expr(
+            :curly,
+            :Union,
+            generate_expr!(exprs, t.a, root_name),
+            generate_expr!(exprs, t.b, root_name),
+        )
+    else
+        return to_ast(T)
+    end
+end
+
+# given the type of a field of a struct, return a node for that field's name/type
+function generate_field_expr!(exprs, t::Type{NamedTuple{N,T}}, root_name::Symbol) where {N,T}
+    generate_expr!(exprs, t, root_name)
+    return Expr(:(::), root_name, pascalcase(root_name))
+end
+
+function generate_field_expr!(exprs, ::Type{Base.Array{T,N}}, root_name::Symbol) where {T,N}
+    return Expr(:(::), root_name, Expr(:curly, :Array, generate_expr!(exprs, T, root_name), 1))
+end
+
+function generate_field_expr!(exprs, ::Type{T}, root_name::Symbol) where {T}
+    return Expr(:(::), root_name, generate_expr!(exprs, T, root_name))
+end
+
+
+macro generatetypes(json_str, name)
+    return quote
+        # either a JSON.Array or JSON.Object
+        local json = JSON3.read(length($(esc(json_str))) < 255 && isfile($(esc(json_str))) ? read($(esc(json_str))) : $(esc(json_str)))
+
+        # build a type for the JSON
+        local raw_json_type = JSON3.generate_type(json)
+        local json_exprs = JSON3.generate_exprs(raw_json_type, $(esc(name)))
+        local exprs = Expr(:block, json_exprs...)
+        return Core.eval($__module__, exprs)
+    end
+end
+
+macro generatetypes(json)
+    :(@generatetypes $(esc(json)) :Root)
+end

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -138,7 +138,7 @@ end
 
 # entry function for turning a "raw" type from `generate_type` to Exprs
 """
-    generate_exprs(raw_type, name=:Root; mutable=true)
+    generate_exprs(raw_type; root_name=:Root, mutable=true)
 
 Generate a vector of `Expr` from a "raw_type".  This will un-nest any sub-types within the root type.
 
@@ -146,9 +146,9 @@ The name of the root type is from the `name` variable (default :Root), then nest
 
 If `mutable` is `true`, an empty constructor is included in the struct definition. This allows the mutable structs to be used with `StructTypes.Mutable()` out of the box.
 """
-function generate_exprs(t, name::Symbol = :Root; mutable = true)
+function generate_exprs(t; root_name::Symbol = :Root, mutable = true)
     exprs = []
-    generate_expr!(exprs, t, name; mutable = mutable)
+    generate_expr!(exprs, t, root_name; mutable = mutable)
     return exprs
 end
 
@@ -271,7 +271,7 @@ function generatetypes(
 
     # build a type for the JSON
     raw_json_type = generate_type(json)
-    json_exprs = generate_exprs(raw_json_type, root_name)
+    json_exprs = generate_exprs(raw_json_type; root_name=root_name)
     return generate_struct_type_module(
         json_exprs,
         module_name

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -207,4 +207,87 @@
         @test length(arr_lines) > 3
         @test arr_lines == lines
     end
+
+    @testset "Macro" begin
+        JSON3.@generatetypes(menu)
+        json = JSON3.read(menu, JSONTypes.Root)
+
+        @test json.menu.header == "SVG\\tViewer\\u03b1"
+        @test length(json.menu.items) > 0
+        @test json.menu.items[0].id == "Open"
+
+        @test fieldnames(JSONTypes.Item) == (:id, :label)
+
+        JSON3.@generatetypes(menu_array, :MyMod)
+        json_arr = JSON3.read(menu_array, MyMod.Root)
+        @test length(json_arr) == 2
+        @test json_arr[1].menu.header == "SVG\\tViewer\\u03b1"
+    end
+
+    @testset "Write & Read" begin
+        path = mktempdir()
+        file_path_default = joinpath(path, "default.jl")
+        JSON3.writetypes(menu, file_path_default)
+
+        include(file_path_default)
+        JSON3.read(menu, JSONTypes.Root)
+
+        @test json.menu.header == "SVG\\tViewer\\u03b1"
+        @test length(json.menu.items) > 0
+        @test json.menu.items[0].id == "Open"
+
+        @test fieldnames(JSONTypes.Item) == (:id, :label)
+
+        file_path_json = joinpath(path, "menu_array.json")
+        Base.write(file_path_json, menu_array)
+        file_path_mod = joinpath(path, "my_mod.jl")
+        JSON3.writetypes(file_path_json, file_path_mod; module_name=:MyMod, root_name=:MenuArray)
+
+        include(file_path_mod)
+        JSON3.read(menu_arr, MyMod.MenuArray)
+        @test length(json_arr) == 2
+        @test json_arr[1].menu.header == "SVG\\tViewer\\u03b1"
+    end
+
+    @testset "Struct" begin
+        json = """
+            [
+                {"a": 1, "b": 2, "c": {"d": 4}},
+                {"a": w, "b": 5, "c": {"d": 4}},
+                {"a": 3, "b": 4, "c": {"d": 6}},
+                {"a": 7, "b": 7, "c": {"d": 7}},
+            ]
+        """
+
+        path = mktempdir()
+        file_path = joinpath(path, "struct.jl")
+
+        JSON3.writetypes(json, file_path; mutable=false)
+        include(file_path)
+        parsed = JSON3.read(json, JSONTypes.Root)
+
+        @test parsed[1].c.d == 4
+    end
+
+    @testset "Raw Types" begin
+        json = """
+            [
+                {"a": 1, "b": 2, "c": 5},
+                {"a": w, "b": 5, "c": 9},
+                {"a": 3, "b": 4, "c": 2},
+                {"a": 7, "b": 7, "c": 0},
+            ]
+        """
+        parsed = JSON3.read(json) # JSON.Object
+
+        # build a type for the JSON
+        raw_json_type = JSON3.generate_type(parsed)
+        @test raw_json_type <: NamedTuple
+
+        StructTypes.StructType(raw_json_type) = StructType.DictType()
+
+        res = JSON3.read(json, raw_json_type)
+
+        @test res[4].b == 7
+    end
 end

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -1,0 +1,210 @@
+@testset "Generate Types" begin
+    menu = """
+    {
+      "menu": {
+        "header": "SVG\\tViewer\\u03b1",
+        "items": [
+          {
+            "id": "Open"
+          },
+          {
+            "id": "OpenNew",
+            "label": "Open New"
+          },
+          {
+            "id": "ZoomIn",
+            "label": "Zoom In"
+          },
+          {
+            "id": "ZoomOut",
+            "label": "Zoom Out"
+          },
+          {
+            "id": "OriginalView",
+            "label": "Original View"
+          },
+          {
+            "id": "Quality"
+          },
+          {
+            "id": "Pause"
+          },
+          {
+            "id": "Mute"
+          },
+          null,
+          {
+            "id": "Find",
+            "label": "Find..."
+          },
+          {
+            "id": "FindAgain",
+            "label": "Find Again"
+          },
+          {
+            "id": "Copy"
+          },
+          {
+            "id": "CopyAgain",
+            "label": "Copy Again"
+          },
+          {
+            "id": "CopySVG",
+            "label": "Copy SVG"
+          },
+          {
+            "id": "ViewSVG",
+            "label": "View SVG"
+          },
+          {
+            "id": "ViewSource",
+            "label": "View Source"
+          },
+          {
+            "id": "SaveAs",
+            "label": "Save As"
+          },
+          null,
+          {
+            "id": "Help"
+          },
+          {
+            "id": "About",
+            "label": "About Adobe SVG Viewer..."
+          }
+        ]
+      }
+    }
+    """
+
+    menu_array = """
+    [
+        {
+          "menu": {
+            "header": "SVG\\tViewer\\u03b1",
+            "items": [
+              {
+                "id": "Open"
+              },
+              {
+                "id": "OpenNew",
+                "label": "Open New"
+              },
+              {
+                "id": "ZoomIn",
+                "label": "Zoom In"
+              },
+              {
+                "id": "ZoomOut",
+                "label": "Zoom Out"
+              },
+              {
+                "id": "OriginalView",
+                "label": "Original View"
+              },
+              {
+                "id": "Quality"
+              },
+              {
+                "id": "Pause"
+              },
+              {
+                "id": "Mute"
+              },
+              null,
+              {
+                "id": "Find",
+                "label": "Find..."
+              },
+              {
+                "id": "FindAgain",
+                "label": "Find Again"
+              },
+              {
+                "id": "Copy"
+              },
+              {
+                "id": "CopyAgain",
+                "label": "Copy Again"
+              },
+              {
+                "id": "CopySVG",
+                "label": "Copy SVG"
+              },
+              {
+                "id": "ViewSVG",
+                "label": "View SVG"
+              },
+              {
+                "id": "ViewSource",
+                "label": "View Source"
+              },
+              {
+                "id": "SaveAs",
+                "label": "Save As"
+              },
+              null,
+              {
+                "id": "Help"
+              },
+              {
+                "id": "About",
+                "label": "About Adobe SVG Viewer..."
+              }
+            ]
+          }
+        },
+        {
+          "menu": {
+            "header": "A second item",
+            "items": [
+              {
+                "id": "Open"
+              },
+              {
+                "id": "OpenNew",
+                "label": "Open New"
+              }
+            ]
+          }
+        }
+    ]
+    """
+
+    @testset "Object & Array" begin
+        json = JSON3.read(menu) # JSON.Object
+
+        # build a type for the JSON
+        raw_json_type = JSON3.generate_type(json)
+        @test raw_json_type <: NamedTuple
+
+        # turn the type into struct expressions, including replacing sub types with references to a struct
+        json_exprs = JSON3.generate_exprs(raw_json_type, :MyStruct)
+        @test length(json_exprs) == 3
+
+        # write the types to a file, then can be edited/included as needed
+        path = mktempdir()
+        file = joinpath(path, "test_type.jl")
+        JSON3.write_exprs(json_exprs, file)
+        lines = readlines(file)
+        @test length(lines) > 3
+
+        json_arr = JSON3.read(menu_array) # JSON.Array
+
+        # build a type for the JSON
+        raw_json_arr_type = JSON3.generate_type(json_arr)
+        @test raw_json_arr_type <: Array
+
+        # turn the type into struct expressions, including replacing sub types with references to a struct
+        json_arr_exprs = JSON3.generate_exprs(raw_json_arr_type, :MyStruct)
+        @test length(json_arr_exprs) == 3
+
+        # write the types to a file, then can be edited/included as needed
+        path = mktempdir()
+        file_arr = joinpath(path, "test_arr.jl")
+        JSON3.write_exprs(json_arr_exprs, file_arr)
+        arr_lines = readlines(file_arr)
+        @test length(arr_lines) > 3
+        @test arr_lines == lines
+    end
+end

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -179,7 +179,7 @@
         @test raw_json_type <: NamedTuple
 
         # turn the type into struct expressions, including replacing sub types with references to a struct
-        json_exprs = JSON3.generate_exprs(raw_json_type, :MyStruct)
+        json_exprs = JSON3.generate_exprs(raw_json_type; root_name=:MyStruct)
         @test length(json_exprs) == 3
 
         # write the types to a file, then can be edited/included as needed
@@ -196,7 +196,7 @@
         @test raw_json_arr_type <: Array
 
         # turn the type into struct expressions, including replacing sub types with references to a struct
-        json_arr_exprs = JSON3.generate_exprs(raw_json_arr_type, :MyStruct)
+        json_arr_exprs = JSON3.generate_exprs(raw_json_arr_type; root_name=:MyStruct)
         @test length(json_arr_exprs) == 3
 
         # write the types to a file, then can be edited/included as needed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -885,6 +885,8 @@ x = JSON3.read(json; jsonlines=true)
 # allow_inf consistency
 @test_throws ArgumentError JSON3.read("-Infinity")
 
+include("gentypes.jl")
+
 end # @testset "JSON3"
 
 include("stringnumber.jl")


### PR DESCRIPTION
Given sample JSON, generate a type.  This is broken down into a few steps, after each there is a potentially usable result:
1. generate a "raw" type from the JSON - likely an unwieldy `Array` or `NamedTuple` (could potentially be used as is with a `StructTypes.DictType()` or `StructTypes.ArrayType()`)
2. generate a set of `struct` `Expr` for this raw type, including pulling out sub-objects as standalone structs (can be `eval`ed at this point to use the types
3. write the struct definitions to file, from here can be manually edited (perhaps to avoid bringing in unneeded fields) and included as needed

There is also an `@generatetypes` macro which completes steps 1 and 2 and returns the expressions to be evaluated in the user's scope.

To do:
- [x] Add tests for the macro
- [x] Add tests for using types to read JSON
- [x] Add tests for usability of "raw" type with `StructTypes.DictType()` or `StructTypes.ArrayType()`
- [x] Add documentation (example in the README, section in the docs)
- [x] Add `mutable` option at expression generation step and for macro
- [x] Convenience function for steps 1-3 combined