### PR TITLE
More robust algorithm for parsing number as Int64 vs. Float64

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,6 +142,19 @@ struct DictWithoutLength end
 @test JSON3.read("true") === true
 @test JSON3.read("false") === false
 
+# more robust Int vs. Float detection: https://github.com/quinnj/JSON3.jl/issues/124
+@test JSON3.read("9223372036854775807") == 9223372036854775807
+@test JSON3.read("9223372036854775808") == 9.223372036854776e18 # overflowed Int64 promotes to Float64 (though slightly lossy)
+@test JSON3.read("-9223372036854775808") == -9223372036854775808
+@test JSON3.read("-9223372036854775809") == -9.223372036854776e18
+# 2^53 boundaries
+@test JSON3.read("9007199254740991") == 9007199254740991
+@test JSON3.read("9007199254740992") == 9007199254740992
+@test JSON3.read("9007199254740993") == 9007199254740993
+@test JSON3.read("9007199254740994") == 9007199254740994
+@test JSON3.read("1e17") == Int64(1e17)
+
+
 @test_throws ArgumentError JSON3.read("{")
 @test JSON3.read("{}") == JSON3.Object()
 @test_throws ArgumentError JSON3.read("{a")


### PR DESCRIPTION
Fixes #124. Whew, a bit of a doozy here. The core issue was our
algorithm parsed a Float64, then did `unsafe_trunc(Int64, float)` and
checked if the two were equal afterwards. The problem is that integers
with greater than 53-bits of precision (like OP's 333333833333500000)
aren't exactly representable in Float64; so while trunc-able to Int64
and therefore equal w/ the float version, we ended up w/ weird answers
like parsing the above number as 333333833333500032, which is the
lossy-conversion Float64 version of the above number.

The new algorithm tries to be smarter about when numbers are allowed to
be converted to Int64, namedly:
  * We call `modf(float)` first to check if even if the float is
  integral; I checked and this is a really fast function, only adds
  1-5ns
  * We then check if the float is in integral range of typemin/typemax
  Int64; now, this is comparing our _float_ value to the integer range,
  which isn't going to be totally precise, so, for example,
  9223372036854775808 passes this test, even though it's one over the
  typemax(Int64)
  * We then check if the float is within the 53-bit precision range
  before calling `unsafe_trunc`
  * If it isn't, we need to reparse the number as a full Int64 to ensure
  we get the exact right integer precision; it's here that we'll also
  pay close attention to the parsing return code in case things
  overflow; if they do, just bump back to the float branch
  * The one other case that's tricky is integers given in float exponent
  form that are > 53-bit precision, like 1e17. We still want to parse
  those as integers (at least to match current behavior), so we detect
  those cases if our integer parsing ends up not parsing the same # of
  digits as the float parsing did (since int parsing will stop at the
  `'e'` character)

Though a bit scary, I think the new algorithm will be much more robust
and follows more strictly the natural boundaries of the Float64
representation. It would probably also be good to document the behavior
in case anybody really needs to know.