### PR TITLE
Support new StructTypes.CustomStruct struct type

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Parsers = "0.3, 1"
-StructTypes = "1.4"
+StructTypes = "1.5"
 julia = "1"
 
 [extras]

--- a/src/structs.jl
+++ b/src/structs.jl
@@ -1,4 +1,4 @@
-import StructTypes: StructType, DictType, ArrayType, StringType, NumberType, BoolType, NullType, NoStructType, Struct, OrderedStruct, Mutable, construct, AbstractType, subtypes, subtypekey
+import StructTypes: StructType, CustomStruct, DictType, ArrayType, StringType, NumberType, BoolType, NullType, NoStructType, Struct, OrderedStruct, Mutable, construct, AbstractType, subtypes, subtypekey
 
 struct RawType <: StructType end
 
@@ -359,6 +359,12 @@ keyvalue(::Type{T}, escaped, ptr, len) where {T} = escaped ? construct(T, unesca
 
 @label invalid
     invalid(error, buf, pos, Object)
+end
+
+@inline function read(::CustomStruct, buf, pos, len, b, ::Type{T}; kw...) where {T}
+    S = StructTypes.lowertype(T)
+    pos, x = read(StructType(S), buf, pos, len, b, S; kw...)
+    return pos, StructTypes.construct(T, x)
 end
 
 mutable struct MutableClosure{T, KW}

--- a/src/write.jl
+++ b/src/write.jl
@@ -122,6 +122,11 @@ end
     return buf, pos, len
 end
 
+@inline function write(::CustomStruct, buf, pos, len, x; kw...)
+    y = StructTypes.lower(x)
+    return write(StructType(y), buf, pos, len, y; kw...)
+end
+
 function write(::DictType, buf, pos, len, x::T; kw...) where {T}
     @writechar '{'
     pairs = StructTypes.keyvaluepairs(x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -125,6 +125,10 @@ DateStruct() = DateStruct(Date(0), DateTime(0), Time(0))
 
 struct DictWithoutLength end
 
+struct Wrapper
+    x::NamedTuple{(:a, :b), Tuple{Int, String}}
+end
+
 @testset "JSON3" begin
 
 @testset "read.jl" begin
@@ -740,6 +744,14 @@ lotsoffields = LotsOfFields(fill("hey", 35)...)
 jlots = JSON3.write(lotsoffields)
 @test jlots == "{\"x1\":\"hey\",\"x2\":\"hey\",\"x3\":\"hey\",\"x4\":\"hey\",\"x5\":\"hey\",\"x6\":\"hey\",\"x7\":\"hey\",\"x8\":\"hey\",\"x9\":\"hey\",\"x10\":\"hey\",\"x11\":\"hey\",\"x12\":\"hey\",\"x13\":\"hey\",\"x14\":\"hey\",\"x15\":\"hey\",\"x16\":\"hey\",\"x17\":\"hey\",\"x18\":\"hey\",\"x19\":\"hey\",\"x20\":\"hey\",\"x21\":\"hey\",\"x22\":\"hey\",\"x23\":\"hey\",\"x24\":\"hey\",\"x25\":\"hey\",\"x26\":\"hey\",\"x27\":\"hey\",\"x28\":\"hey\",\"x29\":\"hey\",\"x30\":\"hey\",\"x31\":\"hey\",\"x32\":\"hey\",\"x33\":\"hey\",\"x34\":\"hey\",\"x35\":\"hey\"}"
 @test JSON3.read(jlots, LotsOfFields) == lotsoffields
+
+StructTypes.StructType(::Type{Wrapper}) = StructTypes.CustomStruct()
+StructTypes.lower(x::Wrapper) = x.x
+StructTypes.lowertype(::Type{Wrapper}) = fieldtype(Wrapper, :x)
+w = Wrapper((a=1, b="hey"))
+json = JSON3.write(w)
+@test json == "{\"a\":1,\"b\":\"hey\"}"
+@test JSON3.read(json, Wrapper) == w
 
 end # @testset "structs.jl"
 


### PR DESCRIPTION
This allows custom unwrapping/wrapping of objects when
serializing/deserializing in a very easy way. Even the support in JSON3
is very minimal; for CustomStruct serialize, we just `lower` the custom
struct and then serialize that. When deserializing, we call `lowertype`
and deserialize whatever that type is, then pass it to
`StructTypes.construct(T, obj)`.