### PR TITLE
Generate code for immutable structs

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -267,7 +267,7 @@ function generatetypes(
 
     # build a type for the JSON
     raw_json_type = generate_type(json)
-    json_exprs = generate_exprs(raw_json_type; root_name=root_name)
+    json_exprs = generate_exprs(raw_json_type; root_name=root_name, mutable=mutable)
     return generate_struct_type_module(
         json_exprs,
         module_name

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -250,6 +250,7 @@
         include(file_path)
         parsed = JSON3.read(json, Vector{JSONTypes.Root})
 
+        @test !(JSONTypes.Root.mutable)
         @test parsed[1].c.d == 4
     end
 


### PR DESCRIPTION
The `mutable` keyword argument was not passed to the code generation method, so immutable structs did not work.