### PR TITLE
Prefer small unions when generating types from json objects/arrays

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -12,8 +12,13 @@ struct Top end
 get_type(NT, k) = hasfield(NT, k) ? fieldtype(NT, k) : Nothing
 
 # unify two types to a single type
+function promoteunion(T, S)
+    new = promote_type(T, S)
+    return isabstracttype(new) ? Union{T, S} : new
+end
+
 unify(a, b) = unify(b, a)
-unify(a::Type{T}, b::Type{S}) where {T,S} = Base.promote_typejoin(T, S)
+unify(a::Type{T}, b::Type{S}) where {T,S} = promoteunion(T, S)
 unify(a::Type{T}, b::Type{S}) where {T,S<:T} = T
 unify(a::Type{Top}, b::Type{T}) where {T} = T
 

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -251,6 +251,7 @@
         parsed = JSON3.read(json, Vector{JSONTypes.Root})
 
         @test parsed[1].c.d == 4
+        @test fieldtype(JSONTypes.Root, 1) == Union{Int, String}
     end
 
     @testset "Raw Types" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -251,7 +251,7 @@
         parsed = JSON3.read(json, Vector{JSONTypes.Root})
 
         @test parsed[1].c.d == 4
-        @test fieldtype(JSONTypes.Root, 1) == Union{Int, String}
+        @test fieldtype(JSONTypes.Root, 1) == Union{Int64, String}
     end
 
     @testset "Raw Types" begin


### PR DESCRIPTION
Fixes #141. In general, the Julia compiler handles Union types really
well these days, so let's prefer them when generating types. Users are
of course always free to modify the generated file if the generated
Union field is too strict.