### PR TITLE
Generate types from an array of JSON samples

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -279,6 +279,26 @@ function generatetypes(
     )
 end
 
+read_json_str(json_str) = read(length(json_str) < 255 && isfile(json_str) ? Base.read(json_str, String) : json_str)
+
+function generatetypes(
+    json_str::Vector{<:AbstractString},
+    module_name::Symbol;
+    mutable::Bool = true,
+    root_name::Symbol = :Root,
+)
+    # either a JSON.Array or JSON.Object
+    json = read_json_str.(json_str)
+
+    # build a type for the JSON
+    raw_json_type = reduce(unify, generate_type.(json); init=Top)
+    json_exprs = generate_exprs(raw_json_type; root_name=root_name, mutable=mutable)
+    return generate_struct_type_module(
+        json_exprs,
+        module_name
+    )
+end
+
 # macro to create a module with types generated from a json string
 """
     @generatetypes json [module_name]

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -255,6 +255,27 @@
         @test fieldtype(JSONTypes.Root, 1) == Union{Int64, String}
     end
 
+    @testset "Array of samples" begin
+        jsons =
+            [
+                "{\"a\": 1, \"b\": 2, \"c\": {\"d\": 4}}",
+                "{\"a\": \"w\", \"b\": 5, \"c\": {\"d\": 4}}",
+                "{\"a\": 3, \"b\": 4, \"c\": {\"d\": 6}}",
+                "{\"a\": 7, \"b\": 7, \"c\": {\"d\": 7}}",
+            ]
+
+
+        path = mktempdir()
+        file_path = joinpath(path, "struct.jl")
+
+        JSON3.writetypes(jsons, file_path; mutable=false)
+        include(file_path)
+        parsed = JSON3.read(jsons[1], JSONTypes.Root)
+
+        @test !(JSONTypes.Root.mutable)
+        @test parsed.c.d == 4
+    end
+
     @testset "Raw Types" begin
         json = """
             [


### PR DESCRIPTION
This is @mcmcgrath13's suggestion from #142. It seems to be working, but the tests break for some reason. I didn't quite figure out why yet. The `JSONTypes` module gets replaced several times during the tests, so I think it has something to do with including the generated code. The generated code itself looks OK.