### PR TITLE
docs: fix dev deploy branch

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,7 +2,7 @@ using Documenter, JSON3, StructTypes
 
 makedocs(;
     modules=[JSON3],
-    format=Documenter.HTML(),
+    format=Documenter.HTML(edit_link="main"),
     pages=[
         "Home" => "index.md",
     ],

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,4 +14,5 @@ makedocs(;
 
 deploydocs(;
     repo="github.com/quinnj/JSON3.jl",
+    devbranch = "main",
 )


### PR DESCRIPTION
Documenter was looking for `master` for the dev deployment, this changes that to `main`