### PR TITLE
Fix: Empty vector returns `Vector{Any}`

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -63,6 +63,10 @@ function generate_type(o::JSON3.Object)
 end
 
 function generate_type(a::JSON3.Array)
+    if isempty(a)
+        return Vector{Any}
+    end
+    
     t = Set([])
     nt = Top
     for item in a

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -11,7 +11,7 @@ get_type(NT, k) = hasfield(NT, k) ? fieldtype(NT, k) : Nothing
 # unify two types to a single type
 function promoteunion(T, S)
     new = promote_type(T, S)
-    return isabstracttype(new) ? Union{T, S} : new
+    return isabstracttype(new) ? Union{T,S} : new
 end
 
 unify(a::Type{T}, b::Type{S}) where {T,S} = promoteunion(T, S)
@@ -42,8 +42,11 @@ function unify(
 
     return NamedTuple{tuple(ks...),Tuple{ts...}}
 end
+unify(a::Type{NamedTuple{A,T}}, b::Type{NamedTuple{A,T}}) where {A,T<:Tuple} =
+    NamedTuple{A,T}
 
 unify(a::Type{Vector{T}}, b::Type{Vector{S}}) where {T,S} = Vector{unify(T, S)}
+unify(a::Type{Vector{T}}, b::Type{Vector{T}}) where {T} = Vector{T}
 
 # parse json into a type, maintain field order
 """
@@ -243,7 +246,9 @@ function generate_struct_type_module(exprs, module_name)
     for expr in exprs
         push!(
             struct_type_decls,
-            Meta.parse("StructTypes.StructType(::Type{$(expr.args[2])}) = StructTypes.$struct_type()"),
+            Meta.parse(
+                "StructTypes.StructType(::Type{$(expr.args[2])}) = StructTypes.$struct_type()",
+            ),
         )
     end
     type_block = Expr(:block, struct_type_import, exprs..., struct_type_decls...)
@@ -270,17 +275,13 @@ function generatetypes(
 )
     # either a JSON.Array or JSON.Object
     json = read(
-        length(json_str) < 255 && isfile(json_str) ? Base.read(json_str, String) :
-            json_str,
+        length(json_str) < 255 && isfile(json_str) ? Base.read(json_str, String) : json_str,
     )
 
     # build a type for the JSON
     raw_json_type = generate_type(json)
-    json_exprs = generate_exprs(raw_json_type; root_name=root_name, mutable=mutable)
-    return generate_struct_type_module(
-        json_exprs,
-        module_name
-    )
+    json_exprs = generate_exprs(raw_json_type; root_name = root_name, mutable = mutable)
+    return generate_struct_type_module(json_exprs, module_name)
 end
 
 # macro to create a module with types generated from a json string
@@ -310,6 +311,6 @@ function writetypes(
     root_name::Symbol = :Root,
     mutable::Bool = true,
 )
-    mod = generatetypes(json, module_name; mutable=mutable, root_name=root_name)
+    mod = generatetypes(json, module_name; mutable = mutable, root_name = root_name)
     write_exprs(mod, file_name)
 end

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -21,6 +21,7 @@ unify(a, b) = unify(b, a)
 unify(a::Type{T}, b::Type{S}) where {T,S} = promoteunion(T, S)
 unify(a::Type{T}, b::Type{S}) where {T,S<:T} = T
 unify(a::Type{Top}, b::Type{T}) where {T} = T
+unify(a::Type{Any}, b::Type{T}) where {T} = T
 
 function unify(
     a::Type{NamedTuple{A,T}},
@@ -66,7 +67,7 @@ function generate_type(a::JSON3.Array)
     if isempty(a)
         return Vector{Any}
     end
-    
+
     t = Set([])
     nt = Top
     for item in a

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -5,9 +5,6 @@
     fieldtypes(::Type{T}) where {T} = Tuple(fieldtype(T, i) for i = 1:fieldcount(T))
 end
 
-# top type - unifying a type with top yeilds the type
-struct Top end
-
 # get the type from a named tuple, given a name
 get_type(NT, k) = hasfield(NT, k) ? fieldtype(NT, k) : Nothing
 
@@ -17,11 +14,13 @@ function promoteunion(T, S)
     return isabstracttype(new) ? Union{T, S} : new
 end
 
-unify(a, b) = unify(b, a)
 unify(a::Type{T}, b::Type{S}) where {T,S} = promoteunion(T, S)
 unify(a::Type{T}, b::Type{S}) where {T,S<:T} = T
-unify(a::Type{Top}, b::Type{T}) where {T} = T
+unify(b::Type{S}, a::Type{T}) where {T,S<:T} = T
+unify(a::Type{T}, b::Type{T}) where {T} = T
 unify(a::Type{Any}, b::Type{T}) where {T} = T
+unify(b::Type{T}, a::Type{Any}) where {T} = T
+unify(a::Type{Any}, b::Type{Any}) = Any
 
 function unify(
     a::Type{NamedTuple{A,T}},
@@ -69,7 +68,7 @@ function generate_type(a::JSON3.Array)
     end
 
     t = Set([])
-    nt = Top
+    nt = Any
     for item in a
         it = generate_type(item)
         if it <: NamedTuple

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -301,6 +301,9 @@
         @test JSON3.unify(Int, String) == Union{Int, String}
         @test JSON3.unify(Float64, Union{Int, String}) == Union{Float64, Int, String}
         @test JSON3.unify(Float64, Real) == Real
+        @test JSON3.unify(Float64, Union{Int, Float64}) == Union{Int, Float64}
+        @test JSON3.unify(Union{Int, Float64}, Float64) == Union{Int, Float64}
+        @test JSON3.unify(Float64, Float64) == Float64
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -296,7 +296,7 @@
         raw_json_type = JSON3.generate_type(JSON3.read(empty_json))
         @test raw_json_type === Vector{Any}
 
-        two_json = """[[], ['hello']]"""
+        two_json = """[[], [\"hello\"]]"""
         raw_json_type = JSON3.generate_type(JSON3.read(two_json))
         @test raw_json_type === Vector{Vector{String}}
 

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -286,6 +286,10 @@
         @test isa(res, raw_json_type)
 
         @test res.b == 2
+
+        empty_json = "[]"
+        raw_json_type = JSON3.generate_type(JSON3.read(empty_json))
+        @test raw_json_type === Vector{Any}
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -296,9 +296,9 @@
         raw_json_type = JSON3.generate_type(JSON3.read(empty_json))
         @test raw_json_type === Vector{Any}
 
-        two_json = """[[], [1]]"""
+        two_json = """[[], ['hello']]"""
         raw_json_type = JSON3.generate_type(JSON3.read(two_json))
-        @test raw_json_type === Vector{Vector{Int}}
+        @test raw_json_type === Vector{Vector{String}}
 
         @test JSON3.unify(Any, Any) == Any
         @test JSON3.unify(Any, Int64) == Int64

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -294,6 +294,13 @@
         two_json = """[[], [1]]"""
         raw_json_type = JSON3.generate_type(JSON3.read(two_json))
         @test raw_json_type === Vector{Vector{Int}}
+
+        @test JSON3.unify(Any, Any) == Any
+        @test JSON3.unify(Any, Int) == Int
+        @test JSON3.unify(Int, Any) == Int
+        @test JSON3.unify(Int, String) == Union{Int, String}
+        @test JSON3.unify(Float64, Union{Int, String}) == Union{Float64, Int, String}
+        @test JSON3.unify(Float64, Real) == Real
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -179,7 +179,7 @@
         @test raw_json_type <: NamedTuple
 
         # turn the type into struct expressions, including replacing sub types with references to a struct
-        json_exprs = JSON3.generate_exprs(raw_json_type; root_name=:MyStruct)
+        json_exprs = JSON3.generate_exprs(raw_json_type; root_name = :MyStruct)
         @test length(json_exprs) == 3
 
         # write the types to a file, then can be edited/included as needed
@@ -196,7 +196,7 @@
         @test raw_json_arr_type <: Array
 
         # turn the type into struct expressions, including replacing sub types with references to a struct
-        json_arr_exprs = JSON3.generate_exprs(raw_json_arr_type; root_name=:MyStruct)
+        json_arr_exprs = JSON3.generate_exprs(raw_json_arr_type; root_name = :MyStruct)
         @test length(json_arr_exprs) == 3
 
         # write the types to a file, then can be edited/included as needed
@@ -225,7 +225,12 @@
         file_path_json = joinpath(path, "menu_array.json")
         Base.write(file_path_json, menu_array)
         file_path_mod = joinpath(path, "my_mod.jl")
-        JSON3.writetypes(file_path_json, file_path_mod; module_name=:MyMod, root_name=:MenuArray)
+        JSON3.writetypes(
+            file_path_json,
+            file_path_mod;
+            module_name = :MyMod,
+            root_name = :MenuArray,
+        )
 
         include(file_path_mod)
         json_arr = JSON3.read(menu_array, Vector{MyMod.MenuArray})
@@ -246,13 +251,13 @@
         path = mktempdir()
         file_path = joinpath(path, "struct.jl")
 
-        JSON3.writetypes(json, file_path; mutable=false)
+        JSON3.writetypes(json, file_path; mutable = false)
         include(file_path)
         parsed = JSON3.read(json, Vector{JSONTypes.Root})
 
         @test !ismutabletype(JSONTypes.Root)
         @test parsed[1].c.d == 4
-        @test fieldtype(JSONTypes.Root, 1) == Union{Int64, String}
+        @test fieldtype(JSONTypes.Root, 1) == Union{Int64,String}
     end
 
     @testset "Raw Types" begin
@@ -298,12 +303,17 @@
         @test JSON3.unify(Any, Any) == Any
         @test JSON3.unify(Any, Int) == Int
         @test JSON3.unify(Int, Any) == Int
-        @test JSON3.unify(Int, String) == Union{Int, String}
-        @test JSON3.unify(Float64, Union{Int, String}) == Union{Float64, Int, String}
+        @test JSON3.unify(Int, String) == Union{Int,String}
+        @test JSON3.unify(Float64, Union{Int,String}) == Union{Float64,Int,String}
         @test JSON3.unify(Float64, Real) == Real
-        @test JSON3.unify(Float64, Union{Int, Float64}) == Union{Int, Float64}
-        @test JSON3.unify(Union{Int, Float64}, Float64) == Union{Int, Float64}
+        @test JSON3.unify(Float64, Union{Int,Float64}) == Union{Int,Float64}
+        @test JSON3.unify(Union{Int,Float64}, Float64) == Union{Int,Float64}
         @test JSON3.unify(Float64, Float64) == Float64
+        @test JSON3.unify(Vector{Int}, Vector{Int}) == Vector{Int}
+        @test JSON3.unify(NamedTuple{(:d,),Tuple{Int}}, NamedTuple{(:d,),Tuple{Int}}) ==
+              NamedTuple{(:d,),Tuple{Int}}
+        @test JSON3.unify(NamedTuple{(:d,),Tuple{Int}}, NamedTuple{(:d,),Tuple{String}}) ==
+              NamedTuple{(:d,),Tuple{Union{Int,String}}}
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -301,19 +301,21 @@
         @test raw_json_type === Vector{Vector{Int}}
 
         @test JSON3.unify(Any, Any) == Any
-        @test JSON3.unify(Any, Int) == Int
-        @test JSON3.unify(Int, Any) == Int
-        @test JSON3.unify(Int, String) == Union{Int,String}
-        @test JSON3.unify(Float64, Union{Int,String}) == Union{Float64,Int,String}
+        @test JSON3.unify(Any, Int64) == Int64
+        @test JSON3.unify(Int64, Any) == Int64
+        @test JSON3.unify(Int64, String) == Union{Int64,String}
+        @test JSON3.unify(Float64, Union{Int64,String}) == Union{Float64,Int64,String}
         @test JSON3.unify(Float64, Real) == Real
-        @test JSON3.unify(Float64, Union{Int,Float64}) == Union{Int,Float64}
-        @test JSON3.unify(Union{Int,Float64}, Float64) == Union{Int,Float64}
+        @test JSON3.unify(Float64, Union{Int64,Float64}) == Union{Int64,Float64}
+        @test JSON3.unify(Union{Int64,Float64}, Float64) == Union{Int64,Float64}
         @test JSON3.unify(Float64, Float64) == Float64
-        @test JSON3.unify(Vector{Int}, Vector{Int}) == Vector{Int}
-        @test JSON3.unify(NamedTuple{(:d,),Tuple{Int}}, NamedTuple{(:d,),Tuple{Int}}) ==
-              NamedTuple{(:d,),Tuple{Int}}
-        @test JSON3.unify(NamedTuple{(:d,),Tuple{Int}}, NamedTuple{(:d,),Tuple{String}}) ==
-              NamedTuple{(:d,),Tuple{Union{Int,String}}}
+        @test JSON3.unify(Vector{Int64}, Vector{Int64}) == Vector{Int64}
+        @test JSON3.unify(NamedTuple{(:d,),Tuple{Int64}}, NamedTuple{(:d,),Tuple{Int64}}) ==
+              NamedTuple{(:d,),Tuple{Int64}}
+        @test JSON3.unify(
+            NamedTuple{(:d,),Tuple{Int64}},
+            NamedTuple{(:d,),Tuple{String}},
+        ) == NamedTuple{(:d,),Tuple{Union{Int64,String}}}
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -290,6 +290,10 @@
         empty_json = "[]"
         raw_json_type = JSON3.generate_type(JSON3.read(empty_json))
         @test raw_json_type === Vector{Any}
+
+        two_json = """[[], [1]]"""
+        raw_json_type = JSON3.generate_type(JSON3.read(two_json))
+        @test raw_json_type === Vector{Vector{Int}}
     end
 
     @testset "Pascal Case" begin


### PR DESCRIPTION
Instead of returning `Vector{JSON3.TopType}`, return a `Vector{Any}` when all of the samples have empty vectors in them.