### PR TITLE
Treat Union{Bool, Real} as StructTypes.Struct

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -48,6 +48,11 @@ end
 
 read(::NoStructType, buf, pos, len, b, ::Type{T}; kw...) where {T} = throw(ArgumentError("$T doesn't have a defined `StructTypes.StructType`"))
 
+# https://github.com/quinnj/JSON3.jl/issues/172
+# treat Union{Bool, Real} as non-StructTypes.NumberType so parsing works as expected
+read(::NumberType, buf, pos, len, b, S::Type{Union{Bool, T}}; kw...) where {T <: Real} =
+    read(Struct(), buf, pos, len, b, S; kw...)
+
 function read(::Struct, buf, pos, len, b, U::Union; kw...)
     # Julia implementation detail: Unions are sorted :)
     # This lets us avoid the below try-catch when U <: Union{Missing,T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -926,6 +926,10 @@ x = JSON3.read(json; jsonlines=true)
 str = JSON3.write(NaNStruct(NaN); allow_inf=true)
 @test JSON3.read(str, NaNStruct; allow_inf=true).x === NaN
 
+# https://github.com/quinnj/JSON3.jl/issues/172
+@test JSON3.read("true", Union{Bool, Int})
+@test JSON3.read("42", Union{Bool, Float64}) === 42.0
+
 include("gentypes.jl")
 include("stringnumber.jl")
 


### PR DESCRIPTION
By default, `Union{Bool, Real}` has struct type `StructTypes.NumberType`
since `Bool <: Integer`, but when parsing a `Bool` or a `Real` from
json, we want to treat them distinctly, by parsing a `Bool` _or_ a
`Real`. The solution here is to just intercept the `read` call for those
`Union` types and pass it to the `Struct` method.