### PR TITLE
Fix dispatch of `Real` when parsing in structs

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -52,6 +52,10 @@ read(::NoStructType, buf, pos, len, b, ::Type{T}; kw...) where {T} = throw(Argum
 # treat Union{Bool, Real} as non-StructTypes.NumberType so parsing works as expected
 read(::NumberType, buf, pos, len, b, S::Type{Union{Bool, T}}; kw...) where {T <: Real} =
     read(Struct(), buf, pos, len, b, S; kw...)
+# https://github.com/quinnj/JSON3.jl/issues/187
+# without this, `Real` dispatches to the above definition
+read(::NumberType, buf, pos, len, b, ::Type{Real}; kw...) =
+    read(NumberType(), buf, pos, len, b, Union{Float64, Int64}; kw...)
 
 function read(::Struct, buf, pos, len, b, U::Union; kw...)
     # Julia implementation detail: Unions are sorted :)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -141,6 +141,18 @@ StructTypes.StructType(::Type{NaNStruct}) = StructTypes.CustomStruct()
 StructTypes.lower(x::NaNStruct) = x.x
 StructTypes.construct(::Type{NaNStruct}, x) = NaNStruct(x)
 
+Base.@kwdef mutable struct System
+    duration::Real = 0 # mandatory
+    cwd::Union{Nothing, String} = nothing
+    environment::Union{Nothing, Dict} = nothing
+    batch::Union{Nothing, Dict} = nothing
+    shell::Union{Nothing, Dict} = nothing
+end
+StructTypes.StructType(::Type{System}) = StructTypes.Mutable()
+StructTypes.omitempties(::Type{System}) = (:cwd, :environment, :batch, :shell)
+
+roundtrip(x::T) where T = JSON3.read(JSON3.write(x), T)
+
 @testset "JSON3" begin
 
 @testset "read.jl" begin
@@ -929,6 +941,10 @@ str = JSON3.write(NaNStruct(NaN); allow_inf=true)
 # https://github.com/quinnj/JSON3.jl/issues/172
 @test JSON3.read("true", Union{Bool, Int})
 @test JSON3.read("42", Union{Bool, Float64}) === 42.0
+
+# https://github.com/quinnj/JSON3.jl/issues/187
+x = System(duration=3600.0)
+@test roundtrip(x).duration == x.duration
 
 include("gentypes.jl")
 include("stringnumber.jl")


### PR DESCRIPTION
Fixes #187. The issue here comes from the fix for
https://github.com/quinnj/JSON3.jl/issues/172, wherein the dispatching
on `Real` when to the `Struct()` code instead of `NumberType`.