### PR TITLE
fix: union unification and collapse

### DIFF
--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -352,6 +352,10 @@
             NamedTuple{(:d,),Tuple{Int64}},
             NamedTuple{(:d,),Tuple{String}},
         ) == NamedTuple{(:d,),Tuple{Union{Int64,String}}}
+        @test JSON3.unify(
+            Union{Nothing, NamedTuple{(:d,),Tuple{Int64}}},
+            NamedTuple{(:d,),Tuple{String}},
+        ) == Union{Nothing, NamedTuple{(:d,),Tuple{Union{Int64,String}}}}
     end
 
     @testset "Pascal Case" begin

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -353,9 +353,17 @@
             NamedTuple{(:d,),Tuple{String}},
         ) == NamedTuple{(:d,),Tuple{Union{Int64,String}}}
         @test JSON3.unify(
-            Union{Nothing, NamedTuple{(:d,),Tuple{Int64}}},
+            Union{Nothing,NamedTuple{(:d,),Tuple{Int64}}},
             NamedTuple{(:d,),Tuple{String}},
-        ) == Union{Nothing, NamedTuple{(:d,),Tuple{Union{Int64,String}}}}
+        ) == Union{Nothing,NamedTuple{(:d,),Tuple{Union{Int64,String}}}}
+        @test JSON3.unify(
+            Union{Nothing,NamedTuple{(:d,),Tuple{Int64}},String},
+            NamedTuple{(:d,),Tuple{String}},
+        ) == Union{Nothing,NamedTuple{(:d,),Tuple{Union{Int64,String}}},String}
+        @test JSON3.unify(
+            Union{Nothing,Vector{NamedTuple{(:d,),Tuple{Int64}}}},
+            Vector{NamedTuple{(:d,),Tuple{String}}},
+        ) == Union{Nothing,Vector{NamedTuple{(:d,),Tuple{Union{Int64,String}}}}}
     end
 
     @testset "Pascal Case" begin


### PR DESCRIPTION
#197 raised an issue where the `collapse_unions!` was erroring on `Vectors`, which has been fixed with a check for `isunion` on both the outer expression and the last argument.  

In investigating this, I also found an issue where a `Union` containing a `Vector` with a complex signature when `promote_type`'d against another `Vector` with a complex signature was returning `Vector{T} where {T}`, thus losing all the type information.

I've made two main changes to address this:

1. The return item from `promote_type` must be concrete to be used
2. After union-ing the two types if `promote_type` result is not concrete, that union is unified (checking for pairs of `Vector` and `NamedTuple` to collapse.  Within the context of generating types, a field should only ever have one `Vector` and one `NamedTuple` within the `Union`.