### PR TITLE
Don't manually inline read on Struct to avoid excessive compilation

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -561,7 +561,7 @@ const DEFAULT_STRUCT_FIELD_COUNT = 32
     return
 end
 
-@inline function read(::Struct, buf, pos, len, b, ::Type{T}; kw...) where {T}
+function read(::Struct, buf, pos, len, b, ::Type{T}; kw...) where {T}
     values = Vector{Any}(undef, DEFAULT_STRUCT_FIELD_COUNT)
     if b != UInt8('{')
         error = ExpectedOpeningObjectChar


### PR DESCRIPTION
Resolves #205. The `@inline` annotation here can lead to excessive
compilation for deeply nested structures where the top-most `Struct`
read call will recursively inline all nested `Struct` read calls. The
function is so large and type-stable anyway that it's not worth inlining
anyway.