### PR TITLE
De-duplicate struct names

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -335,17 +335,17 @@ function generate_expr!(
     root_name::Symbol;
     mutable::Bool = true,
 ) where {N,T<:Tuple}
-    struct_name = pascalcase(root_name)
-    struct_expr = findfirst(e -> e.head == :struct && e.args[2] == struct_name, exprs)
-    if !isnothing(struct_expr) # already a struct with this name, augment it
-        new_struct_name = replace(String(gensym(struct_name)), "#" => "_")
-        @warn "struct with name $struct_name already exists, changing name to $new_struct_name"
-        struct_name = Symbol(new_struct_name)
-    end
-
     sub_exprs = []
     for (n, t) in zip(N, fieldtypes(nt))
         push!(sub_exprs, generate_field_expr!(exprs, t, n; mutable = mutable))
+    end
+
+    struct_name = pascalcase(root_name)
+    struct_expr = findfirst(e -> e.head == :struct && e.args[2] == struct_name, exprs)
+    if !isnothing(struct_expr) # already a struct with this name, augment it
+        new_struct_name = replace(String(gensym(struct_name)), "#" => "")
+        @info "struct with name $struct_name already exists, changing name to $new_struct_name"
+        struct_name = Symbol(new_struct_name)
     end
 
     if mutable
@@ -387,8 +387,8 @@ function generate_field_expr!(
     root_name::Symbol;
     kwargs...,
 ) where {N,T}
-    generate_expr!(exprs, t, root_name; kwargs...)
-    return Expr(:(::), root_name, pascalcase(root_name))
+    struct_name = generate_expr!(exprs, t, root_name; kwargs...)
+    return Expr(:(::), root_name, struct_name)
 end
 
 function generate_field_expr!(

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -341,8 +341,8 @@ function generate_expr!(
     end
 
     struct_name = pascalcase(root_name)
-    struct_expr = findfirst(e -> e.head == :struct && e.args[2] == struct_name, exprs)
-    if !isnothing(struct_expr) # already a struct with this name, augment it
+    struct_exprs = filter(e -> e.head == :struct && e.args[2] == struct_name, exprs)
+    if length(struct_exprs) > 0 # already a struct with this name, augment it
         new_struct_name = replace(String(gensym(struct_name)), "#" => "")
         @info "struct with name $struct_name already exists, changing name to $new_struct_name"
         struct_name = Symbol(new_struct_name)

--- a/test/gentypes.jl
+++ b/test/gentypes.jl
@@ -405,12 +405,36 @@
             path = mktempdir()
             file_path = joinpath(path, "struct.jl")
 
-            JSON3.writetypes(json_str, file_path; module_name=:KeywordType)
+            JSON3.writetypes(json_str, file_path; module_name = :KeywordType)
             include(file_path)
             parsed = JSON3.read(json_str, KeywordType.Root)
 
             @test parsed.end == 1
             @test getproperty(parsed, Symbol("##invalid##")) == 2
         end
+    end
+
+    @testset "Duplicate Names" begin
+        json_str = """
+        {
+            "label": {
+                "type": "alert",
+                "label": [
+                    {
+                        "type": "text",
+                        "text": {
+                            "content": "Open New",
+                            "label": {
+                                "text": "open"
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+        """
+        JSON3.@generatetypes(json_str)
+        json = JSON3.read(json_str, JSONTypes.Root)
+        @test json.label.label[1].text.label.text == "open"
     end
 end


### PR DESCRIPTION
Previous attempt at deduplication was to unify structs with the same name, but I'm still not sure if I like that approach.  In the meantime, this PR just makes sure names are unique across all of the generated structs within the generated module.