### PR TITLE
Simplify "Write with pretty printing" example

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,7 +32,7 @@ using JSON3 # hide
 json_string = """{"a": 1, "b": "hello, world"}"""
 
 hello_world = JSON3.read(json_string)
-JSON3.pretty(JSON3.write(hello_world))
+JSON3.pretty(hello_world)
 ```
 
 #### Read and write from/to a file


### PR DESCRIPTION
Original example says ```JSON3.pretty(JSON3.write(hello_world))``` 
The JSON.write call does not seem necessary and without it the example is more consistent with the "Write pretty JSON to a file" example