### PR TITLE
Make length call on Object more accurate.

### DIFF
--- a/src/JSON3.jl
+++ b/src/JSON3.jl
@@ -34,7 +34,7 @@ $(String(buf[max(1, pos-25):min(end, pos+25)]))
 @enum Error UnexpectedEOF ExpectedOpeningObjectChar ExpectedOpeningQuoteChar ExpectedOpeningArrayChar ExpectedClosingArrayChar ExpectedComma ExpectedSemiColon ExpectedNewline InvalidChar InvalidNumber
 
 # AbstractDict interface
-Base.length(obj::Object) = length(getinds(obj))
+Base.length(obj::Object) = getnontypemask(gettape(obj)[2])
 
 function populateinds!(x::Object)
     inds = getinds(x)


### PR DESCRIPTION
Partial fix for #216. This at least fixes the part where we were inaccurately reporting the length of the object with dupliate keys.