### PR TITLE
Added indentation options to `JSON3.pretty(...)`

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -35,6 +35,23 @@ hello_world = JSON3.read(json_string)
 JSON3.pretty(hello_world)
 ```
 
+The alignment of the string produced  by `JSON3.pretty` can be controlled by
+passing an [`JSON3.AlignmentContext`](@ref) to `JSON3.pretty`. To align each
+level at the `:` Symbol and indent each new level by 2 additional spaces, use
+```@example
+using JSON3 # hide
+json_string = """{"a":"abc","aaaaaaaaaaaaaa":{"a":"abc","aaaaaaaaaaaaaa":"abc"},"c":"abc"}""";
+JSON3.pretty(JSON3.read(json_string), JSON3.AlignmentContext(alignment=:Colon, indent=2))
+```
+to left align the JSON string and indent each new level by 4 additional spaces
+(this is also the default) use
+```@example
+using JSON3 # hide
+json_string = """{"a":"abc","aaaaaaaaaaaaaa":{"a":"abc","aaaaaaaaaaaaaa":"abc"},"c":"abc"}""";
+JSON3.pretty(JSON3.read(json_string), JSON3.AlignmentContext(alignment=:Left, indent=4))
+```
+
+
 #### Read and write from/to a file
 ```jl
 json_string = read("my_file.json", String)
@@ -161,6 +178,7 @@ JSON3.read!
 JSON3.write
 JSON3.pretty
 JSON3.@pretty
+JSON3.AlignmentContext
 JSON3.Object
 JSON3.Array
 Base.copy

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -26,8 +26,8 @@ Base.@kwdef mutable struct AlignmentContext
     offset::UInt16 = 0
     function AlignmentContext(alignment, indent, level, offset)
         if alignment != :Left && alignment != :Colon
-            throw(ArgumentError("Alignment :$(alignment) is not supported. \
-                                 Only :Left and :Colon are supported so far"))
+            throw(ArgumentError("Alignment :$(alignment) is not supported. " * 
+                                 "Only `:Left` and `:Colon` are supported so far"))
         end
         new(alignment, indent, level, offset)
     end

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -68,7 +68,7 @@ function pretty(out::IO, str::String, ac=AlignmentContext(); kw...)
         obj = JSON3.read(str; kw...)
 
         if length(obj) == 0
-            Base.write(out, "}")
+            Base.write(out, ' '^(ac.indent * ac.level + ac.offset) * "}")
             return
         end
 
@@ -98,7 +98,7 @@ function pretty(out::IO, str::String, ac=AlignmentContext(); kw...)
         arr = JSON3.read(str; kw...)
 
         if length(arr) == 0
-            Base.write(out, "]")
+            Base.write(out, ' '^(ac.indent * ac.level + ac.offset) * "]")
             return
         end
 

--- a/src/pretty.jl
+++ b/src/pretty.jl
@@ -8,8 +8,34 @@ macro pretty(json)
 end
 
 """
-    JSON3.pretty(x; kw...)
-    JSON3.pretty(io, x; kw...)
+    JSON3.AlignmentContext(alignment=:Left, indent=4, level=0, offset=0)
+
+Specifies the indentation of a pretty JSON string.
+
+## Keyword Args
+* `alignment`: A Symbol specifying the alignment type. Can be `:Left` to left-align
+               everything or `:Colon` to align at the `:`.
+* `indent`: The number of spaces to indent each new level with.
+* `level`: The indentation level.
+* `offset`: The indentation offset.
+"""
+Base.@kwdef mutable struct AlignmentContext
+    alignment::Symbol = :Left
+    indent::UInt16 = 4
+    level::UInt16 = 0
+    offset::UInt16 = 0
+    function AlignmentContext(alignment, indent, level, offset)
+        if alignment != :Left && alignment != :Colon
+            throw(ArgumentError("Alignment :$(alignment) is not supported. \
+                                 Only :Left and :Colon are supported so far"))
+        end
+        new(alignment, indent, level, offset)
+    end
+end
+
+"""
+    JSON3.pretty(x, ac=JSON3.AlignmentContext(); kw...)
+    JSON3.pretty(io, x, ac=JSON3.AlignmentContext(); kw...)
 
 Pretty print a JSON string.
 
@@ -17,14 +43,16 @@ Pretty print a JSON string.
 
 * `x`: A JSON string, or an object to write to JSON then pretty print.
 * `io`: The `IO` object to write the pretty printed string to. [default `stdout`]
+* `ac`: The `AlignmentContext` for the pretty printing. Defaults to left-aligned
+        with 4 spaces indent. See [`JSON3.AlignmentContext`](@ref) for more options.
 
 ## Keyword Args
 
 See [`JSON3.write`](@ref) and [`JSON3.read`](@ref).
 """
-pretty(str; kw...) = pretty(stdout, str; kw...)
-pretty(out::IO, x; kw...) = pretty(out, JSON3.write(x; kw...); kw...)
-function pretty(out::IO, str::String, indent=0, offset=0; kw...)
+pretty(str, ac=AlignmentContext(); kw...) = pretty(stdout, str, ac; kw...)
+pretty(out::IO, x, ac=AlignmentContext(); kw...) = pretty(out, JSON3.write(x; kw...), ac; kw...)
+function pretty(out::IO, str::String, ac=AlignmentContext(); kw...)
     buf = codeunits(str)
     len = length(buf)
     if len == 0
@@ -46,16 +74,18 @@ function pretty(out::IO, str::String, indent=0, offset=0; kw...)
 
         ks = collect(keys(obj))
         maxlen = maximum(map(sizeof, ks)) + 5
-        indent += 1
+        ac.alignment == :Colon && (ac.offset += maxlen)
+        ac.level += 1
 
         i = 1
         for (key, value) in obj
-            Base.write(out, "  "^indent)
-            Base.write(out, lpad("\"$(key)\"" * ": ", maxlen + offset, ' '))
-            pretty(out, JSON3.write(value; kw...), indent, maxlen + offset; kw...)
+            Base.write(out, ' '^(ac.level * ac.indent))
+            Base.write(out, lpad("\"$(key)\"" * ": ", ac.offset, ' '))
+            pretty(out, JSON3.write(value; kw...), ac; kw...)
             if i == length(obj)
-                indent -= 1
-                Base.write(out, "\n" * ("  "^indent * " "^offset) * "}")
+                ac.level -= 1
+                ac.alignment == :Colon && (ac.offset -= maxlen)
+                Base.write(out, "\n" * ' '^(ac.indent * ac.level + ac.offset) * "}")
             else
                 Base.write(out, ",\n")
                 i += 1
@@ -72,14 +102,14 @@ function pretty(out::IO, str::String, indent=0, offset=0; kw...)
             return
         end
 
-        indent += 1
+        ac.level += 1
 
         for (i, val) in enumerate(arr)
-            Base.write(out, "  "^indent * " "^offset)
-            pretty(out, JSON3.write(val; kw...), indent, offset; kw...)
+            Base.write(out, ' '^(ac.indent * ac.level + ac.offset))
+            pretty(out, JSON3.write(val; kw...), ac; kw...)
             if i == length(arr)
-                indent -= 1
-                Base.write(out, "\n" * ("  "^indent * " "^offset) * "]")
+                ac.level -= 1
+                Base.write(out, "\n" * ' '^(ac.indent * ac.level + ac.offset) * "]")
             else
                 Base.write(out, ",\n")
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -906,7 +906,7 @@ JSON3.pretty(io, "{}")
 @test String(take!(io)) == "{\n}"
 JSON3.pretty(io, "[]")
 @test String(take!(io)) == "[\n]"
-JSON3.pretty(io, (a=1, b=true, c=3.14, d="hey", e=(abcdefghijklmnopqrstuvwxyz=1000, aa=1e8, dd=[nothing, nothing, nothing, 3.14])))
+JSON3.pretty(io, (a=1, b=true, c=3.14, d="hey", e=(abcdefghijklmnopqrstuvwxyz=1000, aa=1e8, dd=[nothing, nothing, nothing, 3.14])), JSON3.AlignmentContext(alignment=:Colon, indent=2))
 @test String(take!(io)) == """{
    "a": 1,
    "b": true,
@@ -923,8 +923,24 @@ JSON3.pretty(io, (a=1, b=true, c=3.14, d="hey", e=(abcdefghijklmnopqrstuvwxyz=10
                                          ]
         }
 }"""
-
-JSON3.pretty(io, (a=1, b=D(1, 3.14, "cool")))
+JSON3.pretty(io, (a=1, b=true, c=3.14, d="hey", e=(abcdefghijklmnopqrstuvwxyz=1000, aa=1e8, dd=[nothing, nothing, nothing, 3.14])))
+@test String(take!(io)) == """{
+    "a": 1,
+    "b": true,
+    "c": 3.14,
+    "d": "hey",
+    "e": {
+        "abcdefghijklmnopqrstuvwxyz": 1000,
+        "aa": 100000000,
+        "dd": [
+            null,
+            null,
+            null,
+            3.14
+        ]
+    }
+}"""
+JSON3.pretty(io, (a=1, b=D(1, 3.14, "cool")), JSON3.AlignmentContext(alignment=:Colon, indent=2))
 @test String(take!(io)) == """{
    "a": 1,
    "b": {
@@ -933,11 +949,20 @@ JSON3.pretty(io, (a=1, b=D(1, 3.14, "cool")))
            "c": "cool"
         }
 }"""
+JSON3.pretty(io, (a=1, b=D(1, 3.14, "cool")))
+@test String(take!(io)) == """{
+    "a": 1,
+    "b": {
+        "a": 1,
+        "b": 3.14,
+        "c": "cool"
+    }
+}"""
 
 # 77
 io = IOBuffer()
 JSON3.pretty(io,  JSON3.write(Dict( "x" => Inf64), allow_inf=true), allow_inf=true )
-@test String(take!(io)) == "{\n   \"x\": Infinity\n}"
+@test String(take!(io)) == "{\n    \"x\": Infinity\n}"
 
 end # @testset "pretty.jl"
 


### PR DESCRIPTION
I added a struct `AlignmentContext` that is passed to `JSON3.pretty(...)` which specifies the indentation type (left- or colon-aligned), the indentation level and spaces per indentation level.

This fixes #161

Please let know if this looks good and if you want me to add a sentence or two to the documentation about this.