### PR TITLE
Add SnoopPrecompile

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.9.5"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
@@ -14,6 +15,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Parsers = "0.3, 1, 2"
 StructTypes = "1.5"
 julia = "1"
+SnoopPrecompile = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/JSON3.jl
+++ b/src/JSON3.jl
@@ -172,4 +172,6 @@ include("write.jl")
 include("pretty.jl")
 include("gentypes.jl")
 
+include("workload.jl")
+
 end # module

--- a/src/workload.jl
+++ b/src/workload.jl
@@ -1,0 +1,19 @@
+using SnoopPrecompile
+
+@precompile_all_calls begin
+    str = """{"a": 1, "b": "hello, world", "c": [1, 2], "d": true, "e": null, "f": 1.92}"""
+
+    JSON3.read(IOBuffer(str))
+    json = JSON3.read(str)
+    for i in "abcdef"
+        json[i]
+    end
+
+    JSON3.read(
+        str,
+        NamedTuple{(:a, :b, :c, :d, :e, :f), Tuple{Int, String, Vector{Int}, Bool, Nothing, Float32}}
+    )
+
+    JSON3.write(IOBuffer(), json)
+    JSON3.pretty(IOBuffer(), json)
+end


### PR DESCRIPTION
The small dependency SnoopPrecompile helps precompilation, while itself having
little impact on latency.
With this change, JSON3 precompiles significantly better.

This change increases time spent on `using`, but decreases inference time for any of the workloads in the `workload.jl` file.

Here are timings for a script which loads JSON3 and executs the same workload in `workload.jl` file on master vs this PR:

```
# Master
Benchmark 1: julia --project=. --startup=no /tmp/foo.jl
  Time (mean ± σ):      3.531 s ±  0.065 s    [User: 3.537 s, System: 0.580 s]
  Range (min … max):    3.453 s …  3.697 s    10 runs

# PR
Benchmark 1: julia --project=. --startup=no /tmp/foo.jl
  Time (mean ± σ):      2.149 s ±  0.031 s    [User: 2.195 s, System: 0.554 s]
  Range (min … max):    2.099 s …  2.206 s    10 runs
```

@quinnj I'm not sure the workload covers all the common use-cases of JSON3, i.e. whether the workload ends up calling all the methods a user would typically call.