### PR TITLE
Add `JSON3.tostring` for Real number overloads when writing

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -182,6 +182,7 @@ JSON3.AlignmentContext
 JSON3.Object
 JSON3.Array
 Base.copy
+JSON3.tostring
 ```
 
 ### In Relation to Other JSON Packages

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1062,4 +1062,8 @@ s1_json = String(take!(iob))
 s2 = JSON3.read(s1_json, Struct1)
 @test s1.iarr == s2.iarr
 
+# https://github.com/quinnj/JSON3.jl/issues/232
+@test JSON3.write(3//2) == "1.5"
+@test JSON3.write(π) == "3.141592653589793"
+1
 end # @testset "JSON3"


### PR DESCRIPTION
This is the best idea I can come up with to address https://github.com/quinnj/JSON3.jl/issues/232. First a summary of the problem,
  * We allow custom number types to overload `StructTypes.numbertype` that we convert to before writing JSON
  * However, we only provide JSON writing routines for `Integer` and `AbstractFloat`
  * So a number like `3//2` (`Rational`) or `π` (`Irrational`) which are both `<: Real`, but not `Integer` or `AbstractFloat` we get the stack overlfow behavior reported above

The proposal here then is we first check if a `Real` has overloaded `StructTypes.numbertype` and _if not_, we'll use a new `JSON3.tostring` method, which by default converts the custom number to `Float64` and then calls `Base.string(x)`. This method allows custom number types, like FixedPointDecimal, to overload `JSON3.tostring` to provide an appropriate string representation for their type.