### PR TITLE
Use `sizeof` rather than `length` for file length check

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -192,7 +192,7 @@ end
 function read_json_str(json)
     # length check is to ensure that isfile doesn't thrown an error
     # see issue for details https://github.com/JuliaLang/julia/issues/39774
-    !(json isa VectorString) && length(json) < 255 && isfile(json) ?
+    !(json isa VectorString) && sizeof(json) < 255 && isfile(json) ?
           VectorString(Mmap.mmap(json)) : 
           json
 end

--- a/test/json.jl
+++ b/test/json.jl
@@ -748,3 +748,11 @@ end
     JSON3.write(path, [1, 2, 3])
     open(JSON3.read, path) == [1, 2, 3]
 end
+
+@test mktemp() do path, io
+    str = "σ"^127
+    JSON3.write(path, str)
+    open(path, "r") do io
+        JSON3.read(io) == str
+    end
+end


### PR DESCRIPTION
This issue only seems to occur when there is a file with contents that contained just enough Unicode characters to push the `sizeof` value over 254 while keeping `length` under that limit. I'd assume that `isfile` really actually cares about number of bytes rather than apparent character length.