### PR TITLE
More robust handling of filenames, paritucalrly errors about too long

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -4,6 +4,7 @@ struct VectorString{T <: AbstractVector{UInt8}} <: AbstractString
 end
 
 Base.codeunits(x::VectorString) = x.bytes
+read_json_str(json::VectorString) = json
 
 # high-level user API functions
 read(io::Union{IO, Base.AbstractCmd}; kw...) = read(Base.read(io, String); kw...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -189,10 +189,22 @@ Base.@pure function symbolin(names::Tuple{Vararg{Symbol}}, name::Symbol)
     return false
 end
 
+read_json_str(json::VectorString) = json
 function read_json_str(json)
     # length check is to ensure that isfile doesn't thrown an error
     # see issue for details https://github.com/JuliaLang/julia/issues/39774
-    !(json isa VectorString) && sizeof(json) < 255 && isfile(json) ?
-          VectorString(Mmap.mmap(json)) : 
-          json
+    isfilename(json) && isfile(json) ?
+        VectorString(Mmap.mmap(json)) :
+        json
+end
+
+isfilename(filename) = try
+    stat(filename)
+    true
+catch e
+    if isa(e, Base.IOError)
+        e.code != -36   # -36 is ENAMETOOLONG; other IO errors indicate valid filename
+    else
+        rethrow()
+    end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -189,7 +189,6 @@ Base.@pure function symbolin(names::Tuple{Vararg{Symbol}}, name::Symbol)
     return false
 end
 
-read_json_str(json::VectorString) = json
 function read_json_str(json)
     # length check is to ensure that isfile doesn't thrown an error
     # see issue for details https://github.com/JuliaLang/julia/issues/39774


### PR DESCRIPTION
On my system, I'm actually triggering the `ENAMETOOLONG` error code with strings of length ~150 characters. Not sure why, but I re-wrote the code based on the [suggestion in the upstream bug](https://github.com/JuliaLang/julia/issues/39774#issuecomment-786797712).