### PR TITLE
add nested getindex to precompile

### DIFF
--- a/src/workload.jl
+++ b/src/workload.jl
@@ -1,13 +1,14 @@
 using PrecompileTools
 
 @compile_workload begin
-    str = """{"a": 1, "b": "hello, world", "c": [1, 2], "d": true, "e": null, "f": 1.92}"""
+    str = """{"a": 1, "b": "hello, world", "c": [1, 2], "d": true, "e": null, "f": 1.92, "g": {"a": {"a" : "b"}}}"""
 
     JSON3.read(IOBuffer(str))
     json = JSON3.read(str)
     for i in "abcdef"
         json[i]
     end
+    json[:g][:a][:a]
 
     JSON3.read(
         str,


### PR DESCRIPTION
The top level getindex is `get(obj::JSON3.Object{Vector{UInt8}, Vector{UInt64}}, key)`, but a nested getindex will be using a subarray so it needs different compilation.  `get(obj::JSON3.Object{Vector{UInt8}, SubArray{UInt64, 1, Vector{UInt64}, Tuple{UnitRange{Int64}}, true}}, key`