### PR TITLE
Remove two inlines slowing down GLTF TTFX on Julia v1.10.3 and bloating compiled dll sizes on Julia v1.10 and v1.11

### DIFF
--- a/src/structs.jl
+++ b/src/structs.jl
@@ -211,7 +211,7 @@ end
 @inline read(::ArrayType, buf, pos, len, b, ::Type{T}, ::Type{eT}; kw...) where {T, eT} = readarray(buf, pos, len, b, T, eT; kw...)
 read(::ArrayType, buf, pos, len, b, ::Type{Tuple}, ::Type{eT}; kw...) where {eT} = readarray(buf, pos, len, b, Tuple, eT; kw...)
 
-@inline function readarray(buf, pos, len, b, ::Type{T}, ::Type{eT}; kw...) where {T, eT}
+function readarray(buf, pos, len, b, ::Type{T}, ::Type{eT}; kw...) where {T, eT}
     if b != UInt8('[')
         error = ExpectedOpeningArrayChar
         @goto invalid
@@ -460,7 +460,7 @@ end
     throw(ArgumentError("read! is only defined when T is of the `Mutable` struct type"))
 end
 
-@inline function read!(::Mutable, buf, pos, len, b, ::Type{T}, x::T; kw...) where {T}
+function read!(::Mutable, buf, pos, len, b, ::Type{T}, x::T; kw...) where {T}
     if b != UInt8('{')
         error = ExpectedOpeningObjectChar
         @goto invalid


### PR DESCRIPTION
Remove two inlines slowing down GLTF TTFX on Julia v1.10.3 and bloating compiled dll sizes on Julia v1.10 and v1.11.
Fixes https://github.com/quinnj/JSON3.jl/issues/279.

### Before 
#### v1.10.3
```
@time using GLTF; @time load(joinpath(pkgdir(GLTF), "assets", "DamagedHelmet.gltf"));
  0.122459 seconds (109.06 k allocations: 7.716 MiB)
  5.278717 seconds (3.35 M allocations: 166.804 MiB, 0.44% gc time, 99.99% compilation time)
```
`6TsRJ_9EZ8v.dll` 41 MB

#### v1.11.0-beta2
```
@time using GLTF; @time load(joinpath(pkgdir(GLTF), "assets", "DamagedHelmet.gltf"));
  0.205132 seconds (139.25 k allocations: 8.620 MiB)
  0.000295 seconds (459 allocations: 27.164 KiB)
```
`6TsRJ_6Xhya.dll` 201 MB

### After
#### v1.10.3
```
@time using GLTF; @time load(joinpath(pkgdir(GLTF), "assets", "DamagedHelmet.gltf"));
  0.112920 seconds (97.59 k allocations: 7.255 MiB)
  0.382297 seconds (688.95 k allocations: 50.071 MiB, 2.85% gc time, 99.85% compilation time)
```
`6TsRJ_bCVAr.dll` 16 MB

#### v1.11.0-beta2
```
@time using GLTF; @time load(joinpath(pkgdir(GLTF), "assets", "DamagedHelmet.gltf"));
  0.211747 seconds (139.25 k allocations: 8.619 MiB)
  0.000334 seconds (459 allocations: 27.164 KiB)
```
`6TsRJ_1Irey.dll` 32 MB