### PR TITLE
Add extra keyword argument for ignoring extra fields

### DIFF
--- a/src/JSON3.jl
+++ b/src/JSON3.jl
@@ -32,7 +32,7 @@ invalid JSON at byte position $pos while parsing type $T: $error
 $(String(buf[max(1, pos-25):min(end, pos+25)]))
 """))
 
-@enum Error UnexpectedEOF ExpectedOpeningObjectChar ExpectedOpeningQuoteChar ExpectedOpeningArrayChar ExpectedClosingArrayChar ExpectedComma ExpectedSemiColon ExpectedNewline InvalidChar InvalidNumber
+@enum Error UnexpectedEOF ExpectedOpeningObjectChar ExpectedOpeningQuoteChar ExpectedOpeningArrayChar ExpectedClosingArrayChar ExpectedComma ExpectedSemiColon ExpectedNewline InvalidChar InvalidNumber ExtraField
 
 # AbstractDict interface
 Base.length(obj::Object) = getnontypemask(gettape(obj)[2])

--- a/src/read.jl
+++ b/src/read.jl
@@ -26,6 +26,7 @@ Read JSON.
 * `dateformat`: A [`DateFormat`](https://docs.julialang.org/en/v1/stdlib/Dates/#Dates.DateFormat) describing the format of dates in the JSON so that they can be read into `Date`s, `Time`s, or `DateTime`s when reading into a type. [default `Dates.default_format(T)`]
 * `parsequoted`: Accept quoted values when reading into a NumberType. [default `false`]
 * `numbertype`: Type to parse numbers as. [default `nothing`, which parses numbers as Int if possible, Float64 otherwise]
+* `ignore_extra_fields`: Ignore extra fields in the JSON when reading into a struct. [default `true`]
 """
 function read(json::AbstractString; jsonlines::Bool=false,
               numbertype::Union{DataType, Nothing}=nothing, kw...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1109,4 +1109,12 @@ y[1] = x
     @testset "Arrow" include("arrow.jl")
 end
 
+# https://github.com/quinnj/JSON3.jl/issues/296
+struct TypeWithoutExtraField
+    a::Int
+end
+string_with_extra_field = "{\"a\": 1, \"b\": 2}"
+@test JSON3.read(string_with_extra_field, TypeWithoutExtraField) == TypeWithoutExtraField(1)
+@test_throws ArgumentError JSON3.read(string_with_extra_field, TypeWithoutExtraField, ignore_extra_fields=false)
+
 end # @testset "JSON3"


### PR DESCRIPTION
Addresses #296 by introducing a new keyword argument that allows the user to opt into throwing an error on encoutering an extra field while parsing into a `struct`.