### PR TITLE
Patch release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JSON3"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com>"]
-version = "1.14.1"
+version = "1.14.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"


### PR DESCRIPTION
Needed after https://github.com/quinnj/JSON3.jl/pull/302#event-15680009063 - it's an important security
fix to use `parse` instead of `read` - if exposed in packages implementing public HTTP APIs it allows people 
to read arbitrary files on the host machine FS
