### PR TITLE
Remove inappropriate `@boundscheck`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,13 @@ jobs:
             version: '1'
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -52,8 +44,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,10 +6,9 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo="https://github.com/quinnj/JSON3.jl/blob/{commit}{path}#L{line}",
+    repo=Remotes.GitHub("quinnj", "JSON3.jl"),
     sitename="JSON3.jl",
     authors="Jacob Quinn",
-    strict=true,
 )
 
 deploydocs(;

--- a/src/write.jl
+++ b/src/write.jl
@@ -65,7 +65,7 @@ end
 
 macro writechar(chars...)
     block = quote
-        @boundscheck @check($(length(chars)))
+        @check($(length(chars)))
     end
     for c in chars
         push!(block.args, quote

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1107,7 +1107,8 @@ y = Vector{UndefGuy}(undef, 2)
 y[1] = x
 @test JSON3.write(y) == "[{\"id\":10},null]"
 
-@static if isdefined(Base, :get_extension)
+# Arrow tests require a 64 bit system
+@static if isdefined(Base, :get_extension) && Sys.WORD_SIZE == 64
     @testset "Arrow" include("arrow.jl")
 end
 


### PR DESCRIPTION
When running julia with `--check-bounds=no`, the package fails to precompile. The reason is that compiler elides `@boundscheck`s, which in this case removes buffer reallocation. I believe that's unwanted.

Issue was [reported on Discourse](https://discourse.julialang.org/t/json3-fails-to-precompile-due-to-embedded-nuls-in-c-strings/128482) by 0samuraiE.