### PR TITLE
Update CI and fix building docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,21 +27,13 @@ jobs:
             version: '1'
             arch: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+          show-versioninfo: true
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -52,8 +44,8 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - run: |

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -6,10 +6,9 @@ makedocs(;
     pages=[
         "Home" => "index.md",
     ],
-    repo="https://github.com/quinnj/JSON3.jl/blob/{commit}{path}#L{line}",
+    repo=Remotes.GitHub("quinnj", "JSON3.jl"),
     sitename="JSON3.jl",
     authors="Jacob Quinn",
-    strict=true,
 )
 
 deploydocs(;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1107,7 +1107,8 @@ y = Vector{UndefGuy}(undef, 2)
 y[1] = x
 @test JSON3.write(y) == "[{\"id\":10},null]"
 
-@static if isdefined(Base, :get_extension)
+# Arrow tests require a 64 bit system
+@static if isdefined(Base, :get_extension) && Sys.WORD_SIZE == 64
     @testset "Arrow" include("arrow.jl")
 end
 


### PR DESCRIPTION
This PR updates GitHub Actions versions, gets the docs building with the new version of Documenter.jl, and fixes the tests by avoiding testing `Arrow` on 32-bit Windows. 